### PR TITLE
Add a shared Maven Build workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,205 @@
+name: Maven Build
+
+on:
+  workflow_call:
+    inputs:
+      DOCKER_PROFILE:
+        required: false
+        type: string
+        default: docker
+        description: |
+          Specifies the name of the profile that enables/disables Docker based tests.
+      USES_DOCKERHUB_IMAGES:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Specifies whether this build needs to pull images from DockerHub.
+      MAVEN_ARGS:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Specifies any additional arguments to pass to the Maven invocations.
+      MAVEN_BUILD_GOALS:
+        required: false
+        type: string
+        default: install
+        description: |
+          Specifies the Maven goal(s) to use when building the project.  Defaults to install.
+      MAVEN_DEPLOY_GOALS:
+        required: false
+        type: string
+        default: deploy
+        description: |
+          Specifies the Maven goal(s) to use when deploying the project, assuming PUBLISH_SNAPSHOTS was set to true and
+          we're on the configured MAIN_BRANCH.  Defaults to deploy.
+      MAVEN_REPOSITORY_ID:
+        required: false
+        type: string
+        default: sonatype-oss
+        description: |
+          Specifies the ID of the repository to which SNAPSHOTs and Releases are published, this MUST match the ID of
+          a repository defined in the pom.xml for the project in order for credentials to be correctly configured.
+      JAVA_VERSION:
+        required: false
+        type: number
+        default: 17
+        description: |
+          Specifies the JDK version to install and build with.  Defaults to 17.
+      JDK:
+        required: false
+        type: string
+        default: temurin
+        description: |
+          Specifies the JDK to use, defaults to temurin.
+      MAIN_BRANCH:
+        required: false
+        type: string
+        default: main
+        description: |
+          Specifies the main branch for the repository.  Used in determining whether to publish SNAPSHOTs in 
+          conjunction with the PUBLISH_SNAPSHOTS parameter.
+      PUBLISH_SNAPSHOTS:
+        required: false
+        type: boolean
+        default: true
+        description: |
+          Specifies whether Maven SNAPSHOTs are published from this build.  Note that even when enabled (as is
+          the default) SNAPSHOTs are only published when a build occurs on the main branch.  The main branch 
+          can be separately configured via the MAIN_BRANCH parameter.
+    secrets:
+      MAVEN_USERNAME:
+        required: false
+        description: |
+          Username for authenticating to a Maven repository to publish SNAPSHOTs, only needed if SNAPSHOT 
+          publishing is enabled.
+      MAVEN_PASSWORD:
+        required: false
+        description: |
+          Password/Token for authenticating to a Maven repository to publish SNAPSHOTs, only needed if SNAPSHOT
+          publishing is enabled.
+      DOCKER_READ_USER:
+        required: false
+        description: |
+          Username for authenticating to DockerHub, only needed if USES_DOCKERHUB_IMAGES is set to true.
+      DOCKER_READ_PWD:
+        required: false
+        description: |
+          Password/Token for authenticating to DockerHub, only needed if USERS_DOCKERHUB_IMAGES is set to true.
+      GPG_PRIVATE_KEY:
+        required: true
+        description: |
+          A GPG Private Key that will be used to sign the built artifacts during the build process.  The pom.xml 
+          MUST invoke the maven-gpg-plugin for this to have an effect.
+      GPG_PASSPHRASE:
+        required: true
+        description: |
+          The passphrase protecting the provided GPG Private Key.
+
+    outputs:
+      version: 
+        description: The detected Maven Version of the project as configured in the top level pom.xml
+        value: ${{ jobs.build.outputs.version }}
+      is-snapshot:
+        description: Whether the Maven build was for a SNAPSHOT version.
+        value: ${{ jobs.build.outputs.version != '' && contains(jobs.build.outputs.version, 'SNAPSHOT') }}
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  cache-dependencies:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          # We intentionally don't configure credentials for the cache dependencies step.  Any dependencies MUST
+          # be in the public artifact repository so fail fast if a project is still relying on private dependencies
+          # that have not been published.
+
+      - name: Cache Maven Dependencies
+        run: |
+          mvn dependency:go-offline --batch-mode
+
+  build:
+    needs: cache-dependencies
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      # These have to be exported into the environment due to how the setup-java action configures the Maven
+      # settings.xml file to avoid directly embedding credentials into it.
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.project.outputs.version }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        if: ${{ inputs.USES_DOCKERHUB_IMAGES && matrix.os == 'ubuntu-latest' }}
+        with:
+          username: ${{ secrets.DOCKER_READ_USER }}
+          password: ${{ secrets.DOCKER_READ_PWD }}
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          server-id: ${{ inputs.MAVEN_REPOSITORY_ID }}
+          # Forced to use indirection here, the setup-java action configures the Maven settings.xml to reference
+          # the credentials via environment variables
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Build and Verify Maven Package
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }}
+
+      - name: Build and Verify Maven Package (Windows - Docker Profile disabled)
+        if: ${{ matrix.os == 'windows-latest' }}
+        # Remember that Windows Action runners DO NOT support Docker so explicitly disable the Docker profile
+        run: |
+          mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }}
+
+      - name: Detect Maven version
+        id: project
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          echo version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) >> $GITHUB_OUTPUT
+
+      # It's safe to skipTests for the Publish step because we just did a full mvn verify in the earlier steps
+      # which will have run all the unit and integration tests
+      - name: Publish Maven SNAPSHOTs
+        if: ${{ inputs.PUBLISH_SNAPSHOTS && matrix.os == 'ubuntu-latest' && github.ref_name == inputs.MAIN_BRANCH && steps.project.outputs.version != '' && contains(steps.project.outputs.version, 'SNAPSHOT') }}
+        run: |
+          mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests ${{ inputs.MAVEN_ARGS }}


### PR DESCRIPTION
Creates an initial version of a public shared Maven workflow for review and testing, this is based off our private shared Maven workflow and modified as so:    

- Remove unnecessary permissions as public version of the workflow does not need `id-token: write` permissions
- Remove AWS steps related to private infrastructure
- Improve how credentials are exported to environment by exporting them at the job level rather than via a specific job step
- Uses latest checkout and setup-java action versions