### PR TITLE
chore: handle release notes extraction better

### DIFF
--- a/.github/workflows/python-gh-release.yml
+++ b/.github/workflows/python-gh-release.yml
@@ -20,22 +20,29 @@ jobs:
         RELEASE="${{ inputs.VERSION }}"
         STARTED=0
         while IFS= read -r LINE; do
-          if [ ${STARTED} -eq 1 ]; then
-            if [[ "${LINE}" == \##\ * ]]; then
-              break
-            fi
-            echo "${LINE}" >> ${{ github.workspace }}-release-notes.txt
-          elif [[ "${LINE}" == \#\#\ [\[?]*${RELEASE}[\]?]* ]]; then
-            STARTED=1
-            echo "${LINE}" >> ${{ github.workspace }}-release-notes.txt
-          fi
+        if [[ "${LINE}" =~ ^##\ (\[${RELEASE}\]|${RELEASE}) ]]; then
+         STARTED=1
+         echo "${LINE}"
+         continue
+        fi
+        if [ ${STARTED} -eq 1 ]; then
+         if [[ "${LINE}" =~ ^[\*-] ]] || [[ "${LINE}" =~ ^\#\#\# ]]; then
+           echo "${LINE}" >>  ${{ github.workspace }}-release-notes.txt
+         else
+           if [[ "${LINE}" =~ ^##\  ]]; then
+             break
+           fi
+         fi
+        fi
         done < "CHANGELOG.md"
-        
         if [ ${STARTED} -eq 0 ]; then
-          echo "Release ${RELEASE} not found in CHANGELOG.md, no CHANGELOG release notes available" 1>&2
+        echo "Release ${RELEASE} not found in the changelog."
+        fi
+        if [ "${STARTED}" -eq 0 ]; then
+               echo "Release ${RELEASE} not found in CHANGELOG.md, no CHANGELOG release notes available" 1>&2
         else
-          echo "Detected Release Notes for ${RELEASE} are:"
-          cat ${{ github.workspace }}-release-notes.txt
+         echo "Detected Release Notes for ${RELEASE} are:"
+         cat "${{ github.workspace }}-release-notes.txt"
         fi
         exit 0
 


### PR DESCRIPTION
Tested against [Telicent-lib/CHANGELOG.md](https://github.com/telicent-oss/telicent-lib/blob/main/CHANGELOG.md) versions 2.0.0, 2.0.2 and another test repository containing single release in `CHANGELOG.md`

---
2.0.0 The initial release of telicent-lib
---
```bash
## 2.0.0 (2024-05-01)
Detected Release Notes for 2.0.0 are:
### Features
* initial release ([c605ee7](https://github.com/telicent-oss/telicent-lib/commit/c605ee76a5dea86585112620b4350855d527ccc5))
```
---
2.0.2 A bug fix version
---
```bash
Run RELEASE="2.0.0"
## 2.0.0 (2024-05-01)
Detected Release Notes for 2.0.0 are:
### Features
* initial release ([c605ee7](https://github.com/telicent-oss/telicent-lib/commit/c605ee76a5dea86585112620b4350855d527ccc5))
```

----
Test repository
----

### CHANGELOG.md
```bash
# Changelog

## 0.1.0 (2024-06-10)


### Features

* init relese test ([838fcd4](https://github.com/gnikolov95/test-gh-release/commit/838fcd454bc9cc60a53940653acaba62ecb192d0))


### Miscellaneous

* point to test ([995a954](https://github.com/gnikolov95/test-gh-release/commit/995a9544a908105413a5dc0a3534d6a1573814f7))
```

```bash
Run RELEASE="0.1.0"
## 0.1.0 (2024-06-10)
Detected Release Notes for 0.1.0 are:
### Features
* init relese test ([838fcd4](https://github.com/gnikolov95/test-gh-release/commit/838fcd454bc9cc60a53940653acaba62ecb192d0))
### Miscellaneous
* point to test ([995a954](https://github.com/gnikolov95/test-gh-release/commit/995a9544a908105413a5dc0a35[34](https://github.com/gnikolov95/test-gh-release/actions/runs/9448527321/job/26022734649#step:3:35)d6a1573814f7))
```
In all scenarios the changelog was parsed as expected.

Screenshot below shows the final results of the release action.
<img width="1309" alt="image" src="https://github.com/telicent-oss/label-builder/assets/140396136/c80e51dd-05d3-44c9-9a26-0d3944275387">

