### PR TITLE
Various improvements to Maven Workflow (CORE-291)

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -103,10 +103,14 @@ jobs:
         run: |
           mvn verify --batch-mode -DskipTests -Dgpg.skip=true
 
+      # The existence of this SBOM is context dependent, some teams build workflows may not generate a
+      # SBOM in this fashion hence continue-on-error: true
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: ${{ github.run_number }}-sbom.json
+
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -58,6 +58,24 @@ on:
           Specifies the main branch for the repository, defaults to main.  If this build is on the configured main
           branch then the latest tag will be added to the image, if the build is on another branch then the development
           tag will be added to the image.
+      USES_MAVEN:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Whether your build requires the JDK and Maven to be present.
+      JAVA_VERSION:
+        required: false
+        type: number
+        default: 21
+        description: |
+          Specifies the JDK version to install and build with.  Defaults to 21.
+      JDK:
+        required: false
+        type: string
+        default: temurin
+        description: |
+          Specifies the JDK to use, defaults to temurin.
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -69,6 +87,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Java and Maven
+        if: ${{ inputs.USES_MAVEN }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+
+      # NB - Assumption here is that this workflow has been called after the Maven workflow has been called so the 
+      #      Maven Cache already has all our dependencies present in it and tests have already passed
+      - name: Quick Maven Build
+        if: ${{ inputs.USES_MAVEN }}
+        run: |
+          mvn verify --batch-mode -DskipTests
 
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Quick Maven Build
         if: ${{ inputs.USES_MAVEN }}
         run: |
-          mvn verify --batch-mode -DskipTests
+          mvn verify --batch-mode -DskipTests -Dgpg.skip=true
 
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,54 +33,55 @@ on:
         type: string
         default: install
         description: |
-          Specifies the Maven goal(s) to use when building the project.  Defaults to install.
+          Specifies the Maven goal(s) to use when building the project.  Defaults to `install`.
       MAVEN_DEPLOY_GOALS:
         required: false
         type: string
         default: deploy
         description: |
-          Specifies the Maven goal(s) to use when deploying the project, assuming PUBLISH_SNAPSHOTS was set to true and
-          we're on the configured MAIN_BRANCH.  Defaults to deploy.
+          Specifies the Maven goal(s) to use when deploying the project, assuming `PUBLISH_SNAPSHOTS` was set to `true`
+          and we're on the configured `MAIN_BRANCH`.  Defaults to `deploy`.
       MAVEN_REPOSITORY_ID:
         required: false
         type: string
         default: sonatype-oss
         description: |
-          Specifies the ID of the repository to which SNAPSHOTs and Releases are published, this MUST match the ID of
-          a repository defined in the pom.xml for the project in order for credentials to be correctly configured.
+          Specifies the ID of the repository to which `SNAPSHOT`s and Releases are published, this **MUST** match 
+          the ID of a repository defined in the `pom.xml` for the project in order for credentials to be correctly 
+          configured.
       JAVA_VERSION:
         required: false
         type: number
-        default: 17
+        default: 21
         description: |
-          Specifies the JDK version to install and build with.  Defaults to 17.
+          Specifies the JDK version to install and build with.  Defaults to 21.
       JDK:
         required: false
         type: string
         default: temurin
         description: |
-          Specifies the JDK to use, defaults to temurin.
+          Specifies the JDK to use, defaults to `temurin`.
       MAIN_BRANCH:
         required: false
         type: string
         default: main
         description: |
-          Specifies the main branch for the repository.  Used in determining whether to publish SNAPSHOTs in 
-          conjunction with the PUBLISH_SNAPSHOTS parameter.
+          Specifies the main branch for the repository.  Used in determining whether to publish `SNAPSHOT`s in 
+          conjunction with the `PUBLISH_SNAPSHOTS` parameter.
       PUBLISH_SNAPSHOTS:
         required: false
         type: boolean
         default: true
         description: |
-          Specifies whether Maven SNAPSHOTs are published from this build.  Note that even when enabled (as is
-          the default) SNAPSHOTs are only published when a build occurs on the main branch.  The main branch 
-          can be separately configured via the MAIN_BRANCH parameter.
+          Specifies whether Maven `SNAPSHOT`s are published from this build.  Note that even when enabled (as is
+          the default) `SNAPSHOT`s are only published when a build occurs on the main branch.  The main branch 
+          can be separately configured via the `MAIN_BRANCH` parameter.
       CHANGELOG_FILE:
         required: false
         type: string
         default: CHANGELOG.md
         description: |
-          Specifies the CHANGELOG file in the repository from which release notes can be extracted.
+          Specifies the Change Log file in the repository from which release notes can be extracted.
       RELEASE_FILES:
         required: false
         type: string
@@ -92,26 +93,26 @@ on:
       MVN_USER_NAME:
         required: false
         description: |
-          Username for authenticating to a Maven repository to publish SNAPSHOTs, only needed if SNAPSHOT 
+          Username for authenticating to a Maven repository to publish `SNAPSHOT`s, only needed if `SNAPSHOT`
           publishing is enabled.
       MVN_USER_PWD:
         required: false
         description: |
-          Password/Token for authenticating to a Maven repository to publish SNAPSHOTs, only needed if SNAPSHOT
+          Password/Token for authenticating to a Maven repository to publish `SNAPSHOT`s, only needed if `SNAPSHOT`
           publishing is enabled.
       DOCKER_READ_USER:
         required: false
         description: |
-          Username for authenticating to DockerHub, only needed if USES_DOCKERHUB_IMAGES is set to true.
+          Username for authenticating to DockerHub, only needed if `USES_DOCKERHUB_IMAGES` is set to true.
       DOCKER_READ_PWD:
         required: false
         description: |
-          Password/Token for authenticating to DockerHub, only needed if USERS_DOCKERHUB_IMAGES is set to true.
+          Password/Token for authenticating to DockerHub, only needed if `USES_DOCKERHUB_IMAGES` is set to true.
       GPG_PRIVATE_KEY:
         required: false
         description: |
-          A GPG Private Key that will be used to sign the built artifacts during the build process.  The pom.xml 
-          MUST invoke the maven-gpg-plugin for this to have an effect.
+          A GPG Private Key that will be used to sign the built artifacts during the build process.  The `pom.xml`
+          **MUST** invoke the `maven-gpg-plugin` for this to have an effect.
       GPG_PASSPHRASE:
         required: false
         description: |
@@ -122,7 +123,7 @@ on:
         description: The detected Maven Version of the project as configured in the top level pom.xml
         value: ${{ jobs.build.outputs.version }}
       is-snapshot:
-        description: Whether the Maven build was for a SNAPSHOT version.
+        description: Whether the Maven build was for a `SNAPSHOT` version.
         value: ${{ jobs.build.outputs.version != '' && contains(jobs.build.outputs.version, 'SNAPSHOT') }}
       
   # Allows you to run this workflow manually from the Actions tab
@@ -285,7 +286,11 @@ jobs:
         # - The declared version for the Maven project is a SNAPSHOT
         if: ${{ steps.gpg-check.outputs.enabled == 'true' && github.actor != 'dependabot[bot]' && inputs.PUBLISH_SNAPSHOTS && matrix.os == 'ubuntu-latest' && github.ref_name == inputs.MAIN_BRANCH && steps.project.outputs.version != '' && contains(steps.project.outputs.version, 'SNAPSHOT') }}
         run: |
-          mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests ${{ inputs.MAVEN_ARGS }}
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }}
+          else
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests ${{ inputs.MAVEN_ARGS }}
+          fi
 
   github-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,13 @@ on:
         default: ""
         description: |
           Specifies any additional arguments to pass to the Maven invocations.
+      MAVEN_DEBUG_ARGS:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Specifies any additional arguments to pass to the Maven invocations when the workflow is run in 
+          debug mode.
       MAVEN_BUILD_GOALS:
         required: false
         type: string
@@ -214,14 +221,22 @@ jobs:
       - name: Build and Verify Maven Package
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          else
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          fi
 
       - name: Build and Verify Maven Package (Windows - Docker Profile disabled)
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
         # Remember that Windows Action runners DO NOT support Docker so explicitly disable the Docker profile
         run: |
-          mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          else
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          fi
 
       - name: Trivy Vulnerability Scan
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -311,7 +326,11 @@ jobs:
       # Note this job only runs after a successful build job so safe to skip tests at this point
       - name: Deploy Maven Release
         run: |
-          mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} -DskipTests
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} -DskipTests
+          else
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} -DskipTests
+          fi
 
       # If a CHANGELOG file has been provided find the developer curated release notes for 
       # the release from that file

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # shared-workflows
+
 Shared workflows for Telicent OSS projects
+
+## Maven Workflows
+
+See the [Maven Workflow](docs/maven.md) documentation for usage.

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -1,0 +1,223 @@
+# Maven Shared Workflow
+
+The Maven Shared Workflow definition may be found [here](../.github/workflows/maven.yml)
+
+This workflow is designed to build Maven based projects and includes automation of `SNAPSHOT` deployment, Maven Central
+releases and GitHub Releases.  See [What this Does](#what-this-workflow-does) for more details on exactly what's
+contained within this workflow.
+
+## Requirements
+
+This workflow has the following requirements:
+
+- The repository it is called from **MUST** contain a `pom.xml` file in the root of the repository
+- The Maven project **MUST** be configured such that it meets the Maven Central requirements, the helper script
+  [`isMavenCentralReady.sh`](../isMavenCentralReady.sh) in this repository can be used to check whether a repository meets these requirements:
+  ```bash
+  $ ./isMavenCentralReady.sh /path/to/repository/
+  ```
+  Which will do a bunch of sanity checks to see if various Maven Central requirements are being met.  This script is not
+  perfect so the first release you attempt to make with this workflow **MAY** still fail in some circumstances.  Telicent developers should refer to our internal documentation on preparing a repository for open source for more specific details.
+
+## Private vs Public Workflow
+
+This is the public version of this workflow for use in open source (public) repositories.  For internal private Telicent
+repositories there is a private workflow whose documentation may be found in the private workflows repository.
+
+The key differences with this workflow versus the private workflow are as follows:
+
+- This workflow automates the deployment of release artifacts to Maven Central
+
+## What this Workflow Does
+
+The shared Maven workflow does the following:
+
+1. A `cache-dependencies` job that:
+    - Configures Java and Maven
+    - Does a `mvn dependency:go-offline` to populate a GitHub Actions Cache used in the subsequent job
+2. A `build` job that:
+    - Configures Java and Maven
+    - Optionally logs into DockerHub if configured to do so (see `USES_DOCKERHUB_IMAGES` in [workflow
+      inputs](#workflow-inputs))
+    - Builds the project with `mvn install`
+    - Scans the project for high/critical severity vulnerabilities attaching reports to the build
+   vulnerabilities with `trivy`
+    - Adds the detected Maven project version (value of `project.version`) to the job outputs
+    - Optionally deploys `SNAPSHOT`s if the build is a `SNAPSHOT` and it's on the `MAIN_BRANCH`, and `PUBLISH_SNAPSHOTS`
+      is configured appropriately, i.e. `mvn deploy -DskipTests`, tests are skipped as this step only runs if the
+      earlier full build was successful
+3. A `github-release` job that runs only when the built version is not a `SNAPSHOT` and the workflow was triggered from
+   a Git tag:
+    - Configures Java and Maven
+    - Does a quick Maven build (`mvn install -DskipTests`) since this job is dependent on the `build` job being
+      successful which does a full build
+    - Deploys the release to Maven Central
+    - Extracts release notes from the configured `CHANGELOG_FILE` (if possible) and detects whether GitHub Release Note
+      auto-generation is configured on the repository
+    - Generates a GitHub
+
+Note that many aspects of the above may be configured via [workflow inputs](#workflow-inputs).
+
+## Simple Usage Example
+
+Here's an example usage of the workflow:
+
+```yaml
+name: Maven Build
+
+on:
+  # Run workflow for any push to a branch or a tag
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
+
+jobs:
+  maven-build:
+    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@main
+    with:
+      # Want SNAPSHOTs to be published from main
+      PUBLISH_SNAPSHOTS: true
+      # Included more detailed logging when debugging (i.e. re-running failed tasks)
+      MAVEN_DEBUG_ARGS: -Dlogback.configurationFile=logback-debug.xml
+    secrets: inherit
+```
+
+Key notes:
+
+- You **MUST** include `secrets: inherit` when calling the reusable workflow otherwise releases won't succeed
+- Your workflow trigger criteria **MUST** include a `tags` trigger otherwise the `github-release` job will
+never be run.
+
+### Combining with other workflows
+
+In the following example we do a Maven build first and then trigger some Docker builds if that succeeds:
+
+```yaml
+name: Complex Build
+
+on:
+  # Run workflow for any push to a branch or a tag
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
+
+# Only permit one build per branch/tag, except on release branches where we want all
+# builds to proceed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: ${{ !contains(github.ref_name, 'release/') }}
+    
+jobs:
+  maven-build:
+    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@main
+    with:
+      # Some Docker based tests in this repository use public images
+      USES_DOCKERHUB_IMAGES: true
+      # Want SNAPSHOTs to be published from main
+      PUBLISH_SNAPSHOTS: true
+      MAIN_BRANCH: main
+      MAVEN_ARGS: -Dtest.maxForks=1
+      # If running in debug mode, use appropriate logging
+      MAVEN_DEBUG_ARGS: -Dlogback.configurationFile=logback-debug.xml
+      JAVA_VERSION: 21
+      CHANGELOG_FILE: CHANGELOG.md
+    secrets: inherit
+
+  docker-build:
+    strategy:
+      matrix:
+        image: [ example-image, another-example-image ]
+      fail-fast: false
+    needs: maven-build
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@main
+    with:
+      APP_NAME: ${{ matrix.image }}
+      APP_NAME_PREFIX: ""
+      PATH: .
+      DOCKERFILE: docker/Dockerfile
+      VERSION: ${{ needs.maven-build.outputs.version }}
+      TARGET: ${{ matrix.image }}
+      BUILD_ARGS: |
+        PROJECT_VERSION=${{ needs.maven-build.outputs.version }}
+      USES_MAVEN: true
+      JAVA_VERSION: 21
+    secrets: inherit
+```
+
+Key Notes:
+
+- Notice that we've added a `concurrency` section to the workflow file to limit the concurrency of our builds. This is
+  optional but is often useful to speed up 
+- The `docker-build` job uses the `needs` parameter to ensure it only runs after a successful run of the `maven-build`
+  job.
+- We can refer to the Maven version of the built project via the `needs.maven-build.outputs.version` variable in
+  subsequent jobs.
+
+## FAQs
+
+### Do I need a release branch?
+
+No, some repositories may prefer to do it this way because of how they've configured
+[concurrency](#combining-with-other-workflows) in their workflow files, but is isn't required.
+
+The workflow will produce an automatic GitHub release when you tag the repository provided that the tag does not point
+to a `SNAPSHOT` version.
+
+### How do I make a release?
+
+Use the Maven release plugin from your development machine:
+
+```bash
+$ mvn release:clean release:prepare -DreleaseVersion=1.2.3 -DdevelopmentVersion=1.2.4-SNAPSHOT -Dtag=1.2.3
+```
+
+Replacing the versions and tag with the appropriate values for your repository.
+
+Go to the GitHub Actions tab for your repository and wait for the build triggered by your tag to complete successfully.
+Once this has completed then your release has been pushed to Maven Central and will be visible there in 30 minutes to 4
+hours.
+
+### Why does the GitHub Release not contain any release notes?
+
+Firstly, have you ensured that you have a `CHANGELOG.md` or equivalent file in your repository?  If this is named
+something other than `CHANGELOG.md` then please set the [`CHANGELOG_FILE`](#workflow-inputs) input accordingly.
+
+Secondly, the release note extraction is based on reading through the Change Log and finding a line that starts `#
+<version>` where `<version>` is the declared version of your release.  It then grabs all lines from that point onwards
+until the next line starting with a `#`.  If your Change Log is formatted differently, or there is no section for the
+current release, then this will not be successfully detected.
+
+### Can I generate release notes automatically instead?
+
+Yes, if you provide a `.github/release.yml` file in your repository then you can take advantage of GitHub's [Automatic
+Release
+Notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)
+
+# Workflow Inputs
+
+The following table provides a complete reference to the available inputs.
+
+| Name | Required? | Type | Default | Description |
+|------|-----------|------|---------|-------------|
+| `CHANGELOG_FILE` | `false ` | `string ` | `CHANGELOG.md ` | Specifies the Change Log file in the repository from which release notes can be extracted.   |
+| `DOCKER_PROFILE` | `false ` | `string ` | `docker ` | Specifies the name of the profile that enables/disables Docker based tests.   |
+| `JAVA_VERSION` | `false ` | `number ` | `21 ` | Specifies the JDK version to install and build with.  Defaults to 21.   |
+| `JDK` | `false ` | `string ` | `temurin ` | Specifies the JDK to use, defaults to `temurin`.   |
+| `MAIN_BRANCH` | `false ` | `string ` | `main ` | Specifies the main branch for the repository.  Used in determining whether to publish `SNAPSHOT`s in  conjunction with the `PUBLISH_SNAPSHOTS` parameter.   |
+| `MAVEN_ARGS` | `false ` | `string ` |  | Specifies any additional arguments to pass to the Maven invocations.   |
+| `MAVEN_BUILD_GOALS` | `false ` | `string ` | `install ` | Specifies the Maven goal(s) to use when building the project.  Defaults to `install`.   |
+| `MAVEN_DEBUG_ARGS` | `false ` | `string ` |  | Specifies any additional arguments to pass to the Maven invocations when the workflow is run in  debug mode.   |
+| `MAVEN_DEPLOY_GOALS` | `false ` | `string ` | `deploy ` | Specifies the Maven goal(s) to use when deploying the project, assuming `PUBLISH_SNAPSHOTS` was set to `true` and we're on the configured `MAIN_BRANCH`.  Defaults to `deploy`.   |
+| `MAVEN_REPOSITORY_ID` | `false ` | `string ` | `sonatype-oss ` | Specifies the ID of the repository to which `SNAPSHOT`s and Releases are published, this **MUST** match  the ID of a repository defined in the `pom.xml` for the project in order for credentials to be correctly  configured.   |
+| `PUBLISH_SNAPSHOTS` | `false ` | `boolean ` | `true ` | Specifies whether Maven `SNAPSHOT`s are published from this build.  Note that even when enabled (as is the default) `SNAPSHOT`s are only published when a build occurs on the main branch.  The main branch  can be separately configured via the `MAIN_BRANCH` parameter.   |
+| `RELEASE_FILES` | `false ` | `string ` | `null ` | Specifies the release files that should be attached to the GitHub release.  For example a  downloadable package that is generated from the repository.  Regardless of this value we  will always attach the SBOMs to the release.   |
+| `USES_DOCKERHUB_IMAGES` | `false ` | `boolean ` | `false ` | Specifies whether this build needs to pull images from DockerHub.   |
+

--- a/isMavenCentralReady.sh
+++ b/isMavenCentralReady.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+ERRORS=0
+function abort() {
+    echo "  FAIL: $*" 1>&2
+    if [ -z "${CONTINUE_ON_ERROR}" ]; then
+      exit 1
+    else
+      ERRORS=$(( ${ERRORS} + 1))
+    fi
+}
+
+function verified() {
+    echo "  PASS: $*"
+}
+
+DIRECTORY=$1
+pushd "${DIRECTORY}" || abort "Invalid directory (${DIRECTORY}) supplied"
+if [ ${ERRORS} -gt 0 ]; then
+  exit 1
+fi
+
+if [ ! -f pom.xml ]; then
+  abort "Not a Maven project, no top level pom.xml in ${DIRECTORY}"
+  exit 1
+fi
+
+function getMavenProperty() {
+    local POM=$1
+    local PROPERTY=$2
+    mvn -q -f "${POM}" -Dexec.executable=echo -Dexec.args="\${${PROPERTY}}" --non-recursive exec:exec
+}
+
+function hasMavenProperty() {
+    local POM=$1
+    local PROPERTY=$2
+    local EXPECTED=$3
+    local VALUE=$(getMavenProperty "${POM}" "${PROPERTY}")
+    if [ -z "${VALUE}" ]; then
+      abort "POM file ${POM} does not have the required Maven Property ${PROPERTY} set"
+      return
+    else
+       local TRIMMED_VALUE=$(echo "${VALUE}" | tr -d ' ')
+       if [ -z "${TRIMMED_VALUE}" ]; then
+         abort "POM file ${POM} does not have the required Maven Property ${PROPERTY} set"
+         return
+       fi
+    fi
+    if [ -n "${EXPECTED}" ]; then
+      if [ "${VALUE}" != "${EXPECTED}" ]; then
+        abort "POM file ${POM} does not have the expected value for Maven Property ${PROPERTY} set, expected ${EXPECTED} but found ${VALUE}"
+        return
+      fi
+    fi
+
+    verified "Verified POM file ${POM} has required Maven Property ${PROPERTY} set as:"
+    verified "${VALUE}"
+}
+
+function hasMavenConfiguration() {
+    local POM=$1
+    local XPATH=$2
+    local DESCRIPTION=$3
+    local EXPECTED=$4
+
+    local VALUE=$(xidel -se "${XPATH}" "/tmp/pom.xml")
+
+    if [ -z "${VALUE}" ]; then
+      abort "POM file ${POM} does not have ${DESCRIPTION}"
+      return
+    fi
+    if [ -n "${EXPECTED}" ]; then
+      if [ "${EXPECTED}" != "${VALUE}" ]; then
+        abort "POM file ${POM} does not have the expected value for ${DESCRIPTION}, expected ${EXPECTED} but found ${VALUE}"
+        return
+      fi
+    fi
+    
+    verified "Verified POM file ${POM} has ${DESCRIPTION}"
+}
+
+function hasMavenArtifact() {
+    local POM=$1
+    local BUILD_DIR="$(dirname ${POM})/target/"
+    local FILE=$2
+    local DESCRIPTION=$2
+
+    if [ ! -f "${BUILD_DIR}${FILE}" ]; then
+      abort "POM file ${POM} does not produce a ${DESCRIPTION} in its target/ directory"
+      return
+    else
+      verified "Verified POM file ${POM} produces a ${DESCRIPTION}"
+    fi
+}
+
+echo "Quick Building the Maven Project..."
+mvn clean install -DskipTests >/dev/null 2>&1 || abort "Maven Build Failed"
+echo "Maven Build completed"
+echo "---"
+echo
+
+for POM in $(find . -name pom.xml); do
+  echo "Testing POM file ${POM}..."
+  pwd
+
+  # Check for Basic Metadata
+  echo "Basic Metadata Checks..."
+  hasMavenProperty "${POM}" "project.version"
+  hasMavenProperty "${POM}" "project.name"
+  hasMavenProperty "${POM}" "project.description"
+  hasMavenProperty "${POM}" "project.url"
+
+  echo "Advanced Metadata Checks..."
+  rm /tmp/pom.xml
+  mvn -f "${POM}" help:effective-pom -Doutput=/tmp/pom.xml >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    abort "POM file ${POM} could not have an effective POM file generated for it"
+    continue
+  fi
+
+  # Check for Licenses
+  hasMavenConfiguration "${POM}" "//project[last()]/licenses[1]/license/url" "<licenses> section"
+
+  # Check for Developers
+  hasMavenConfiguration "${POM}" "//project[last()]/developers[1]/developer/email" "<developers> section" "opensource@telicent.io"
+
+  # Check for SCM Information
+  hasMavenConfiguration "${POM}" "//project[last()]/scm/url" "<scm> section"
+
+  # Check for Distribution Management
+  hasMavenConfiguration "${POM}" "//project[last()]/distributionManagement/repository/url" "<distributionManagement> section" "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+  # Check aritifacts
+  echo "Artifact Checks..."
+  PACKAGING=$(getMavenProperty "${POM}" "project.packaging")
+  ARTIFACT_ID=$(getMavenProperty "${POM}" "project.artifactId")
+  VERSION=$(getMavenProperty "${POM}" "project.version")
+  echo "POM file ${POM} has packaging type ${PACKAGING}"
+
+  if [ "${PACKAGING}" != "pom" ]; then
+    hasMavenArtifact "${POM}" "${ARTIFACT_ID}-${VERSION}.jar" "JAR File"
+    hasMavenArtifact "${POM}" "${ARTIFACT_ID}-${VERSION}-sources.jar" "Sources JAR"
+    hasMavenArtifact "${POM}" "${ARTIFACT_ID}-${VERSION}-javadoc.jar" "Javadoc JAR"
+  fi
+  hasMavenArtifact "${POM}" "${ARTIFACT_ID}-${VERSION}-bom.json" "JSON SBOM"
+  hasMavenArtifact "${POM}" "${ARTIFACT_ID}-${VERSION}-bom.xml" "XML SBOM"
+
+  # Verifying Signatures are present
+  echo "Signature Checks..."
+  for ARTIFACT in $(find "$(dirname ${POM})/target" -type f -not -name "*.asc" -d 1); do
+    EXTENSION=${ARTIFACT##*.}
+    case ${EXTENSION} in
+      "txt"|"log")
+        continue
+        ;;
+      *)
+        if [ ! -f "${ARTIFACT}.asc" ]; then
+          abort "POM file ${POM} produces artifact ${ARTIFACT} that does not have a corresponding digital signature file"
+        else
+          verified "Verified POM file ${POM} generates digital signature for artifact ${ARTIFACT}"
+        fi
+        ;;
+    esac
+  done
+
+  echo "---"
+  echo
+done
+
+if [ ${ERRORS} -gt 0 ]; then
+  echo "Maven Project in ${DIRECTORY} had various errors, please see above output for details"
+  exit 1
+else
+  echo "Maven Project in ${DIRECTORY} appears ready for Maven Central"
+fi


### PR DESCRIPTION
- Added optional `MAVEN_DEBUG_ARGS` based on @TelicentPaul's approach
- Improved self-documentation of inputs in Maven Workflow
- Default JDK now upgraded to 21
- Docker Workflow can now trigger a quick Maven build prior to the Docker build
- Added developer documentation for Maven workflow
- Allow a recently introduced step in the Docker build workflow to be skipped when it isn't applicable to how a team produces SBOMs