### PR TITLE
Dependabot Triggered Builds don't try to push images

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -167,7 +167,8 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          # Dependabot triggered PRs don't have credentials to push images
+          push: ${{ github.actor != 'dependabot[bot]' }}
           context: ${{ inputs.PATH }}
           file: ${{ inputs.DOCKERFILE }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Dependabot triggered builds have access to a much reduced set of secrets meaning that they can only read images from our DockerHub and not push them.  Thus set the value of the push input to `true` **only** when the actor for a build is not Dependabot

Example Dependabot triggered build that fails because of this - https://github.com/telicent-oss/smart-caches-core/actions/runs/9496984988/job/26303783168