### PR TITLE
Additional checks on Maven properties

### DIFF
--- a/isMavenCentralReady.sh
+++ b/isMavenCentralReady.sh
@@ -65,6 +65,12 @@ function hasMavenProperty() {
         return
       fi
     fi
+    # NB - If the Maven property isn't defined Maven doesn't interpolate the property expression and we just get the
+    #      expression echo'd back to us so double check for that case!!
+    if [ "${VALUE}" == "\${${PROPERTY}}" ]; then
+      abort "POM file ${POM} does not set required Maven Property ${PROPERTY}"
+      return
+    fi
 
     verified "Verified POM file ${POM} has required Maven Property ${PROPERTY} set as:"
     verified "${VALUE}"

--- a/isMavenCentralReady.sh
+++ b/isMavenCentralReady.sh
@@ -162,7 +162,7 @@ for POM in $(find . -name pom.xml); do
   fi
   
   # Check nothing is pointing at private GitHub organisation
-  grep -Fi "/telicent-io/" "${POM}" >/dev/null 2>&1
+  grep -Fi "telicent-io" "${POM}" >/dev/null 2>&1
   if [ $? -eq 0 ]; then
     abort "POM file ${POM} still contains a reference to the private telicent-io GitHub organisation"
   else
@@ -209,6 +209,14 @@ for POM in $(find . -name pom.xml); do
   echo "---"
   echo
 done
+
+# Check nothing is pointing at private GitHub organisation
+grep -Fi "telicent-io" .github/workflows/*
+if [ $? -eq 0 ]; then
+  abort "Some GitHub Actions workflow files still contains a reference to workflows in the private telicent-io GitHub organisation"
+else
+  verified "GitHub Actions workflow file does not reference workflows in private telicent-io GitHub organisation"
+fi
 
 if [ ${ERRORS} -gt 0 ]; then
   echo "Maven Project in ${DIRECTORY} had various errors, please see above output for details"


### PR DESCRIPTION
If the Maven property isn't defined mvn just echos the property expression as-is without the value being interpolated which meant it incorrectly passed the sanity check.  Now double check for this case and fail the sanity check if so.

Discovered with @TelicentPaul as he was working through his first attempt at the open source release process