### PR TITLE
Dependabot skips Image Scans

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -180,6 +180,9 @@ jobs:
     needs: build
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
     secrets: inherit
+    # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
+    # an image for it to pull down and scan
+    if: ${{ github.actor != 'dependabot[bot]' }}
     with:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}


### PR DESCRIPTION
As Dependabot triggered builds only have read credentials for the Docker Hub registry they already don't push the built images.  However, this means that when the scan image workflow is triggered it tries to pull a non-existent image and fails.

For example see https://github.com/telicent-oss/smart-caches-core/actions/runs/9553292061/job/26332421007

Thus we now skip the image scan workflow for Dependabot builds.