### PR TITLE
fix: python release managed by release please

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -176,6 +176,12 @@ jobs:
           build-args: |
             ${{ inputs.BUILD_ARGS }}
 
+  scan-dockerfile-configuration:
+    uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main
+    with:
+      DOCKERFILE: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }}
+      SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
+
   scan-image:
     needs: build
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -180,6 +180,9 @@ jobs:
     needs: build
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
     secrets: inherit
+    # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
+    # an image for it to pull down and scan
+    if: ${{ github.actor != 'dependabot[bot]' }}
     with:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}

--- a/.github/workflows/trivy-dockerfile-scan.yml
+++ b/.github/workflows/trivy-dockerfile-scan.yml
@@ -1,0 +1,52 @@
+name: Scan Container Image with Trivy
+
+on:
+  workflow_call:
+    inputs:
+      SCAN_NAME:
+        type: string
+        description: |
+          A developer friendly name for the image to diffentiate scan reports where a repository is
+          building multiple images.
+      DOCKERFILE:
+        type: string
+        description: |
+          Specifies the full path to the Dockerfile within the repository.
+        required: true
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  misconfiguration-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Trivy Docker Misconfiguration Scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "config"
+          scan-ref: ${{ inputs.DOCKERFILE }}
+          output: trivy-docker-misconfiguration-report.json
+          format: json
+          exit-code: 0
+
+      - name: Upload Misconfiguration Scan Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-docker-misconfiguration-report-${{ inputs.SCAN_NAME }}
+          path: trivy-docker-misconfiguration-report.json
+          retention-days: 30
+  
+      - name: Fail Build on High/Critical Misconfigurations
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "config"
+          scan-ref: ${{ inputs.DOCKERFILE }}
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: 1


### PR DESCRIPTION
Handling the release with gh-release doesn't correctly tag the PR, preventing release-please creating a release PR on the next merge to main.

This is a fix for that issue, using release-please to handle the release sequentially to ensure it completes before the boms are attached.