### PR TITLE
feat(deploy): ALLOW_MUTABLE_TAGS & packages

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -86,7 +86,7 @@ on:
         required: false
         type: string
         default: .
-        description: Name of package which SBOM, if it exists
+        description: If release has multiple package that are SBOM targets, then set this to disambiguate SBOMs
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -196,7 +196,7 @@ jobs:
 
   scan-image:
     needs: build
-    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@update/for-frontend-trivy
+    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -76,6 +76,17 @@ on:
         default: temurin
         description: |
           Specifies the JDK to use, defaults to temurin.
+      ALLOW_MUTABLE_TAGS:
+        required: false
+        type: boolean
+        default: true
+        description: |
+          Set `false` to avoid adding mutable tags like `latest` and `development` e.g. if AWS ECR has mutable tags disabled, and 400s
+      package-directory:
+        required: false
+        type: string
+        default: .
+        description: Name of package which SBOM, if it exists
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -83,7 +94,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,13 +116,13 @@ jobs:
         run: |
           mvn verify --batch-mode -DskipTests -Dgpg.skip=true
 
-      # The existence of this SBOM is context dependent, some teams build workflows may not generate a
-      # SBOM in this fashion hence continue-on-error: true
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4
+        # Unsure if SBOM exists (for now)
         continue-on-error: true
         with:
-          name: ${{ github.run_number }}-sbom.json
+          name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
+          path: ${{ inputs.PATH }} 
 
       - name: Set up Docker buildx
         id: buildx
@@ -158,9 +171,8 @@ jobs:
             type=semver,pattern={{version}}
             type=sha,format=long,prefix=
             type=raw,value=${{ inputs.VERSION }}${{ inputs.VERSION_SUFFIX }}
-            type=raw,value=latest,enable=${{ github.ref_name == inputs.MAIN_BRANCH }}
-            type=raw,value=development,enable=${{ github.ref_name != inputs.MAIN_BRANCH}}
-
+            type=raw,value=latest,enable=${{ inputs.ALLOW_MUTABLE_TAGS && github.ref_name == inputs.MAIN_BRANCH }}
+            type=raw,value=development,enable=${{ inputs.ALLOW_MUTABLE_TAGS && github.ref_name != inputs.MAIN_BRANCH}}
       - name: Build, tag, and push image to authenticated docker registry
         id: build-images
         uses: docker/build-push-action@v4
@@ -170,7 +182,7 @@ jobs:
           # Dependabot triggered PRs don't have credentials to push images
           push: ${{ github.actor != 'dependabot[bot]' }}
           context: ${{ inputs.PATH }}
-          file: ${{ inputs.DOCKERFILE }}
+          file: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }}
           tags: ${{ steps.meta.outputs.tags }}
           target: ${{ inputs.TARGET }}
           build-args: |
@@ -184,7 +196,7 @@ jobs:
 
   scan-image:
     needs: build
-    uses: Telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@update/for-frontend-trivy
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan
@@ -192,4 +204,3 @@ jobs:
     with:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
-      RELEASE_SBOM_FILE: trivy-image-scan-sbom-${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.json

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -13,11 +13,6 @@ on:
         description: |
           Specifies the full image reference (repository, name and tag) for an image you wish to scan.
         required: true
-      RELEASE_SBOM_FILE:
-        type: string
-        description: |
-          If release (i.e. has tags), the SBOM for image will be generated and attached to releases
-        required: true
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -45,6 +40,8 @@ jobs:
           output: trivy-docker-report.json
           format: json
           exit-code: 0
+          # See TELFE-211
+          scanners: "vuln"
 
       - name: Upload Vulnerability Scan Results
         uses: actions/upload-artifact@v4
@@ -52,26 +49,32 @@ jobs:
           name: trivy-docker-report-${{ inputs.SCAN_NAME }}
           path: trivy-docker-report.json
           retention-days: 30
+
       - name: Generate SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
         uses: aquasecurity/trivy-action@0.20.0
         with:
           scan-type: 'image'
           format: 'cyclonedx'
-          output: ${{ inputs.RELEASE_SBOM_FILE }}
+          output: trivy-image-scan-sbom-${{ inputs.SCAN_NAME }}.json
           image-ref: ${{ inputs.IMAGE_REF }}
+          # See TELFE-211
+          scanners: "vuln"
+
       - name: Release SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: |
-              ${{ inputs.RELEASE_SBOM_FILE }}
+            trivy-image-scan-sbom-${{ inputs.SCAN_NAME }}.json
+
       - name: Release report on docker sbom (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: |
             trivy-docker-report.json
+
       - name: Fail Build on High/Critical Vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
@@ -81,3 +84,5 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
+          # See TELFE-211
+          scanners: "vuln"

--- a/.github/workflows/vulnerability-scanning-on-repo.yml
+++ b/.github/workflows/vulnerability-scanning-on-repo.yml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
       - run: LOCAL_MACHINE=false yarn install --frozen-lockfile --network-concurrency 1
       - run: yarn global add @cyclonedx/cyclonedx-npm
-      #  --ignore-npm-errors: See https://github.com/CycloneDX/cyclonedx-node-npm/issues/810#issuecomment-1594252293
+      # RE: --ignore-npm-errors below: See https://github.com/CycloneDX/cyclonedx-node-npm/issues/810#issuecomment-1594252293
       - run: cyclonedx-npm --ignore-npm-errors --output-file ./${{ env.BOM_FILE_NAME }}
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4
@@ -64,7 +64,7 @@ jobs:
       - generate_bom
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact       
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
@@ -106,7 +106,7 @@ jobs:
       - generate_bom
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact       
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
@@ -122,7 +122,7 @@ jobs:
           format: 'table'
           output: trivy-sbom-HIGH-CRITICAL-vuln-report.txt
       - run: cat trivy-sbom-HIGH-CRITICAL-vuln-report.txt
-      - name: Download artifact       
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
@@ -137,7 +137,7 @@ jobs:
       - generate_bom
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact       
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json

--- a/.github/workflows/vulnerability-scanning-on-repo.yml
+++ b/.github/workflows/vulnerability-scanning-on-repo.yml
@@ -11,15 +11,19 @@ on:
         required: false
         default: .
         type: string
+      package-directory:
+        required: false
+        default: .
+        type: string
 
 env:
-  BOM_FILE_PATH: "${{ inputs.working-directory }}/${{ inputs.APP_NAME }}.sbom.json"
+  BOM_FILE_NAME: "${{ inputs.APP_NAME }}${{ inputs.package-directory != '.' && inputs.package-directory || '' }}.sbom.json"
 
 jobs:
   generate_bom:
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ./${{ inputs.package-directory }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -33,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: 20
       - name: Get node version
         id: node
         run: |
@@ -49,12 +53,12 @@ jobs:
       - run: LOCAL_MACHINE=false yarn install --frozen-lockfile --network-concurrency 1
       - run: yarn global add @cyclonedx/cyclonedx-npm
       #  --ignore-npm-errors: See https://github.com/CycloneDX/cyclonedx-node-npm/issues/810#issuecomment-1594252293
-      - run: cyclonedx-npm --ignore-npm-errors --output-file ${{ env.BOM_FILE_PATH }}
+      - run: cyclonedx-npm --ignore-npm-errors --output-file ./${{ env.BOM_FILE_NAME }}
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.run_number }}-sbom.json
-          path: ${{ env.BOM_FILE_PATH }}
+          name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
+          path: ${{ inputs.package-directory }}/${{ env.BOM_FILE_NAME }}
   run_vulnerability_scanner:
     needs:
       - generate_bom
@@ -63,19 +67,21 @@ jobs:
       - name: Download artifact       
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.run_number }}-sbom.json
+          name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
       - name: Scan SBOM, report as table file
         uses: aquasecurity/trivy-action@master
         with:
           exit-code: '0' # always pass
           scan-type: 'sbom'
-          scan-ref: ${{ env.BOM_FILE_PATH }} # Need; See /aquasecurity/trivy-action/pull/314
+          scan-ref: ${{ inputs.working-directory }}/${{ env.BOM_FILE_NAME }} # Need; See /aquasecurity/trivy-action/pull/314
           scanners: 'vuln'
           format: 'table'
           output: trivy-sbom-vuln-report.txt
       - run: cat trivy-sbom-vuln-report.txt
       - name: Attach trivy-sbom-vuln-report.txt to release
         uses: softprops/action-gh-release@v2
+        # Unsure if file is empty (for now)
+        continue-on-error: true
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
@@ -85,7 +91,7 @@ jobs:
         with:
           exit-code: '0' # always pass
           scan-type: 'sbom'
-          scan-ref: ${{ env.BOM_FILE_PATH }} # Need; See /aquasecurity/trivy-action/pull/314
+          scan-ref: ${{ inputs.working-directory }}/${{ env.BOM_FILE_NAME }} # Need; See /aquasecurity/trivy-action/pull/314
           scanners: 'vuln'
           output: trivy-sbom-vuln-report.json
           format: json
@@ -103,14 +109,14 @@ jobs:
       - name: Download artifact       
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.run_number }}-sbom.json
+          name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
           exit-code: '0' # Don't kill, this run is just output
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
-          scan-ref: ${{ env.BOM_FILE_PATH }} # Need; See /aquasecurity/trivy-action/pull/314
+          scan-ref: ${{ inputs.working-directory }}/${{ env.BOM_FILE_NAME }} # Need; See /aquasecurity/trivy-action/pull/314
           scan-type: 'sbom'
           scanners: 'vuln'
           format: 'table'
@@ -119,13 +125,13 @@ jobs:
       - name: Download artifact       
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.run_number }}-sbom.json
+          name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
       - name: Release sbom
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ${{ env.BOM_FILE_PATH }}
+            ${{ inputs.working-directory }}/${{ env.BOM_FILE_NAME }}
   test_high_risk_vulnerability_scanner:
     needs:
       - generate_bom
@@ -134,14 +140,14 @@ jobs:
       - name: Download artifact       
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.run_number }}-sbom.json
+          name: ${{ github.run_number }}${{ inputs.package-directory }}.sbom.json
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
           exit-code: '1' # Kill job if fail
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
-          scan-ref: ${{ env.BOM_FILE_PATH }} # Need; See /aquasecurity/trivy-action/pull/314
+          scan-ref: ${{ inputs.working-directory }}/${{ env.BOM_FILE_NAME }} # Need; See /aquasecurity/trivy-action/pull/314
           scan-type: 'sbom'
           scanners: 'vuln'
           format: 'table'


### PR DESCRIPTION
# Ticket: 

https://telicent.atlassian.net/browse/TELFE-290

# Desc

- `ALLOW_MUTABLE_TAGS`
	- Set `false` to avoid adding mutable tags like `latest` and `development` e.g. if AWS ECR has mutable tags disabled, and 400s. 
	- For some Frontend images in ECR, mutable tags was disabled. And so ECR will reject tags like `:latest`
- `package-directory`
	- If release has multiple package that are SBOM targets, then set this to disambiguate SBOMs
	- Telicent-access has 2 images, one for API and one for UI, and the Github release needs SBOMs for both

# Engineering notes

- I hope none of these telicent-oss/shared-workflows may have broken some of the other devs' workflows in 
- So input on the risk would be handy.