### PR TITLE
feat(javascript-test-feature-branch.yml): yarn-test-command

### DIFF
--- a/.github/workflows/javascript-test-feature-branch.yml
+++ b/.github/workflows/javascript-test-feature-branch.yml
@@ -7,6 +7,11 @@ on:
         default: "."
         type: string
         description: directory to run all run commands from
+      yarn-test-command:
+        required: false
+        default: "test"
+        type: string
+        description: Yarn test command e.g. "test" or "test:ci"
 
 jobs:
   quality:
@@ -45,6 +50,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: run integrated tests
-        run: yarn test
+        run: yarn ${{ inputs.yarn-test-command }}
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}


### PR DESCRIPTION
Adds a workflow input for the js "test command"

e.g. `yarn test`  or `yarn test:ci`

Is in use by Telicent access: https://github.com/search?q=org%3Atelicent-oss%20javascript-test-feature-branch%2Fyarn-test-command&type=code