### PR TITLE
Adds a Parallel Maven Build workflow

### DIFF
--- a/.github/workflows/maven-cache-dependencies.yml
+++ b/.github/workflows/maven-cache-dependencies.yml
@@ -1,0 +1,47 @@
+name: Maven Cache Dependencies
+
+on:
+  workflow_call:
+    inputs:
+      JAVA_VERSION:
+        required: false
+        type: number
+        default: 21
+        description: |
+          Specifies the JDK version to install and build with.  Defaults to 21.
+      JDK:
+        required: false
+        type: string
+        default: temurin
+        description: |
+          Specifies the JDK to use, defaults to `temurin`.
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  cache-dependencies:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          # We intentionally don't configure credentials for the cache dependencies step.  Any dependencies MUST
+          # be in the public artifact repository so fail fast if a project is still relying on private dependencies
+          # that have not been published.
+
+      - name: Cache Maven Dependencies
+        run: |
+          mvn dependency:go-offline --batch-mode

--- a/.github/workflows/maven-github-release.yml
+++ b/.github/workflows/maven-github-release.yml
@@ -1,0 +1,165 @@
+name: Maven GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      DOCKER_PROFILE:
+        required: false
+        type: string
+        default: docker
+        description: |
+          Specifies the name of the profile that enables/disables Docker based tests.
+      MAVEN_ARGS:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Specifies any additional arguments to pass to the Maven invocations.
+      MAVEN_DEBUG_ARGS:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Specifies any additional arguments to pass to the Maven invocations when the workflow is run in 
+          debug mode.
+      MAVEN_DEPLOY_GOALS:
+        required: false
+        type: string
+        default: deploy
+        description: |
+          Specifies the Maven goal(s) to use when deploying the project, assuming `PUBLISH_SNAPSHOTS` was set to `true`
+          and we're on the configured `MAIN_BRANCH`.  Defaults to `deploy`.
+      MAVEN_REPOSITORY_ID:
+        required: false
+        type: string
+        default: sonatype-oss
+        description: |
+          Specifies the ID of the repository to which `SNAPSHOT`s and Releases are published, this **MUST** match 
+          the ID of a repository defined in the `pom.xml` for the project in order for credentials to be correctly 
+          configured.
+      JAVA_VERSION:
+        required: false
+        type: number
+        default: 21
+        description: |
+          Specifies the JDK version to install and build with.  Defaults to 21.
+      JDK:
+        required: false
+        type: string
+        default: temurin
+        description: |
+          Specifies the JDK to use, defaults to `temurin`.
+      CHANGELOG_FILE:
+        required: false
+        type: string
+        default: CHANGELOG.md
+        description: |
+          Specifies the Change Log file in the repository from which release notes can be extracted.
+      RELEASE_FILES:
+        required: false
+        type: string
+        description: |
+          Specifies the release files that should be attached to the GitHub release.  For example a 
+          downloadable package that is generated from the repository.  Regardless of this value we 
+          will always attach the SBOMs to the release.
+    secrets:
+      MVN_USER_NAME:
+        required: false
+        description: |
+          Username for authenticating to a Maven repository to publish `SNAPSHOT`s, only needed if `SNAPSHOT`
+          publishing is enabled.
+      MVN_USER_PWD:
+        required: false
+        description: |
+          Password/Token for authenticating to a Maven repository to publish `SNAPSHOT`s, only needed if `SNAPSHOT`
+          publishing is enabled.
+      GPG_PRIVATE_KEY:
+        required: false
+        description: |
+          A GPG Private Key that will be used to sign the built artifacts during the build process.  The `pom.xml`
+          **MUST** invoke the `maven-gpg-plugin` for this to have an effect.
+      GPG_PASSPHRASE:
+        required: false
+        description: |
+          The passphrase protecting the provided GPG Private Key.
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      # These have to be exported into the environment due to how the setup-java action configures the Maven
+      # settings.xml file to avoid directly embedding credentials into it.
+      MAVEN_USERNAME: ${{ secrets.MVN_USER_NAME }}
+      MAVEN_PASSWORD: ${{ secrets.MVN_USER_PWD }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          server-id: ${{ inputs.MAVEN_REPOSITORY_ID }}
+          # Forced to use indirection here, the setup-java action configures the Maven settings.xml to reference
+          # the credentials via environment variables
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      # Note this job only runs after a successful build job so safe to skip tests at this point
+      - name: Deploy Maven Release
+        run: |
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} -DskipTests
+          else
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} -DskipTests
+          fi
+
+      - name: Detect Maven version
+        id: project
+        run: |
+          echo version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) >> $GITHUB_OUTPUT
+
+      # If a CHANGELOG file has been provided find the developer curated release notes for 
+      # the release from that file
+      - name: Extract Release Notes
+        id: release-notes
+        uses: telicent-oss/extract-release-notes-action@v1
+        with:
+          changelog-file: ${{ inputs.CHANGELOG_FILE }}
+          version: ${{ steps.project.outputs.version }}
+          attach-release-notes: true
+          job-summary: true
+          # Allow for the Change Log file to not exist, in which case we get blank release
+          # notes generated
+          fail-if-missing: false
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0 # v2.0.6
+        with:
+          body_path: ${{ steps.release-notes.outputs.release-notes-file }}
+          generate_release_notes: ${{ steps.release-notes.outputs.auto-release-notes }}
+          name: ${{ steps.project.outputs.version }}
+          prerelease: false
+          # We grab the CycloneDX BOMs we're generating plus any release files the workflow inputs specify
+          files: |
+            **/*-bom.json
+            ${{ inputs.RELEASE_FILES }}
+        
+        

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -284,3 +284,4 @@ jobs:
       MAVEN_ARGS: ${{ inputs.MAVEN_ARGS }}
       MAVEN_DEBUG_ARGS: ${{ inputs.MAVEN_DEBUG_ARGS }}
       MAVEN_DEPLOY_GOALS: ${{ inputs.MAVEN_DEPLOY_GOALS }}
+    secrets: inherit

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -306,3 +306,4 @@ jobs:
       MAVEN_ARGS: ${{ inputs.MAVEN_ARGS }}
       MAVEN_DEBUG_ARGS: ${{ inputs.MAVEN_DEBUG_ARGS }}
       MAVEN_DEPLOY_GOALS: ${{ inputs.MAVEN_DEPLOY_GOALS }}
+    secrets: inherit

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -121,10 +121,10 @@ on:
     outputs:
       version: 
         description: The detected Maven Version of the project as configured in the top level pom.xml
-        value: ${{ jobs.build.outputs.version }}
+        value: ${{ jobs.scan-and-publish.outputs.version }}
       is-snapshot:
         description: Whether the Maven build was for a `SNAPSHOT` version.
-        value: ${{ jobs.build.outputs.version != '' && contains(jobs.build.outputs.version, 'SNAPSHOT') }}
+        value: ${{ jobs.scan-and-publish.outputs.version != '' && contains(jobs.scan-and-publish.outputs.version, 'SNAPSHOT') }}
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -136,32 +136,90 @@ jobs:
       JAVA_VERSION: ${{ inputs.JAVA_VERSION }}
       JDK: ${{ inputs.JDK }}
 
-  build:
+  detect-modules:
     needs: cache-dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      modules: ${{ steps.modules.outputs.modules }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+
+      # NB - This is needed because sometimes Maven won't resolve internal project dependencies
+      #      if this is the very first build for that version e.g. just after a version bump
+      - name: Quick Maven Build
+        run: |
+          mvn install -DskipTests -Dgpg.skip -q
+
+      - name: Detect Maven Modules
+        id: modules
+        run: |
+          echo -n "modules=" >> "$GITHUB_OUTPUT"
+          mvn exec:exec -Dexec.executable=echo -Dexec.args='${project.artifactId}' -q | jq --raw-input --slurp -c 'split("\n") | map(select(. != ""))' >> "${GITHUB_OUTPUT}"
+  
+  build:
+    needs: detect-modules
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        module: ${{ fromJSON(needs.detect-modules.outputs.modules) }} 
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+      
+      - name: Install Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+
+      - name: Build Required Modules without Tests
+        run: |
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -U -P${{ inputs.DOCKER_PROFILE }} -pl :${{ matrix.module }} -am -DskipTests -Dgpg.skip ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }}
+          else
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -U -P${{ inputs.DOCKER_PROFILE }} -pl :${{ matrix.module }} -am -DskipTests -Dgpg.skip ${{ inputs.MAVEN_ARGS }}
+          fi
+
+      - name: Build and Verify Maven Module
+        run: |
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -U -P${{ inputs.DOCKER_PROFILE }} -pl :${{ matrix.module }} -Dgpg.skip ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }}
+          else
+            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -U -P${{ inputs.DOCKER_PROFILE }} -pl :${{ matrix.module }} -Dgpg.skip ${{ inputs.MAVEN_ARGS }}
+          fi
+    
+  scan-and-publish:
+    needs: build
+    runs-on: ubuntu-latest
     env:
       # These have to be exported into the environment due to how the setup-java action configures the Maven
       # settings.xml file to avoid directly embedding credentials into it.
       MAVEN_USERNAME: ${{ secrets.MVN_USER_NAME }}
       MAVEN_PASSWORD: ${{ secrets.MVN_USER_PWD }}
     permissions:
+      id-token: write
       contents: read
     outputs:
       version: ${{ steps.project.outputs.version }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
-      
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        if: ${{ inputs.USES_DOCKERHUB_IMAGES && matrix.os == 'ubuntu-latest' }}
-        with:
-          username: ${{ secrets.DOCKER_READ_USER }}
-          password: ${{ secrets.DOCKER_READ_PWD }}
 
       - name: Install Java and Maven
         uses: actions/setup-java@v4
@@ -176,7 +234,6 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Check whether GPG Signing is Enabled
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         id: gpg-check
         run: |
           if [ "${{ secrets.GPG_PRIVATE_KEY }}" != "" ]; then
@@ -186,7 +243,7 @@ jobs:
           fi
 
       - name: Import GPG key
-        if: ${{ matrix.os == 'ubuntu-latest' && steps.gpg-check.outputs.enabled == 'true' }}
+        if: ${{ steps.gpg-check.outputs.enabled == 'true' }}
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -194,33 +251,12 @@ jobs:
 
       - name: Generate Extra Maven Arguments (if needed)
         id: extra-maven-args
-        if: ${{ matrix.os == 'windows-latest' || steps.gpg-check.outputs.enabled == 'false' }}
+        if: ${{ steps.gpg-check.outputs.enabled == 'false' }}
         shell: bash
         run: |
           echo "args=-Dgpg.skip=true" >> "$GITHUB_OUTPUT"
 
-      - name: Build and Verify Maven Package
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
-            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
-          else
-            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
-          fi
-
-      - name: Build and Verify Maven Package (Windows - Docker Profile disabled)
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: bash
-        # Remember that Windows Action runners DO NOT support Docker so explicitly disable the Docker profile
-        run: |
-          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
-            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
-          else
-            mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
-          fi
-
       - name: Trivy Vulnerability Scan
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "fs"
@@ -230,7 +266,6 @@ jobs:
           exit-code: 0
 
       - name: Upload Vulnerability Scan Results
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: actions/upload-artifact@v4
         with:
           name: trivy-report
@@ -238,7 +273,6 @@ jobs:
           retention-days: 30
 
       - name: Fail build on High/Criticial Vulnerabilities
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "fs"
@@ -250,31 +284,19 @@ jobs:
 
       - name: Detect Maven version
         id: project
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           echo version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) >> $GITHUB_OUTPUT
 
-      # It's safe to skipTests for the Publish step because we just did a full mvn verify in the earlier steps
-      # which will have run all the unit and integration tests
+      # NB - It's safe to skipTests for the Publish step because we just did a full mvn verify in the previous step
+      #      which will have run all the unit and integration tests
       - name: Publish Maven SNAPSHOTs
-        # We only publish if all the following are true:
-        # - GPG Key was provided for signing
-        # - The build was not triggered by Dependabot
-        # - The PUBLISH_SNAPSHOTS input was set to true
-        # - We're building on the ubuntu runner
-        # - We're on the configured MAIN_BRANCH 
-        # - The declared version for the Maven project is a SNAPSHOT
-        if: ${{ steps.gpg-check.outputs.enabled == 'true' && github.actor != 'dependabot[bot]' && inputs.PUBLISH_SNAPSHOTS && matrix.os == 'ubuntu-latest' && github.ref_name == inputs.MAIN_BRANCH && steps.project.outputs.version != '' && contains(steps.project.outputs.version, 'SNAPSHOT') }}
+        if: ${{ inputs.PUBLISH_SNAPSHOTS && github.ref_name == inputs.MAIN_BRANCH && steps.project.outputs.version != '' && contains(steps.project.outputs.version, 'SNAPSHOT') }}
         run: |
-          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
-            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }}
-          else
-            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests ${{ inputs.MAVEN_ARGS }}
-          fi
+          mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -DskipTests -Daether.connector.basic.parallelPut=false ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
 
   github-release:
-    needs: build
-    if: ${{ github.ref_type == 'tag' && needs.build.outputs.version != '' && !contains(needs.build.outputs.version, 'SNAPSHOT') }}
+    needs: scan-and-publish
+    if: ${{ github.ref_type == 'tag' && needs.scan-and-publish.outputs.version != '' && !contains(needs.scan-and-publish.outputs.version, 'SNAPSHOT') }}
     uses: telicent-oss/shared-workflows/.github/workflows/maven-github-release.yml@parallel-maven
     with:
       CHANGELOG_FILE: ${{ inputs.CHANGELOG_FILE }}


### PR DESCRIPTION
Similar to what's already been done for private workflows this adds a parallel Maven build workflow.  This can speed up builds for larger repositories significantly as build time is determined by the slowest building module, not the total build time of all modules.

Tested on https://github.com/telicent-oss/smart-caches-core/actions/runs/10698176791 (our current slowest building open source Java repository) and gave a ~10 minute reduction in build time