### PR TITLE
Add missing QEMU setup to Docker workflows (TELDEVOPS-374)

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -111,6 +111,11 @@ jobs:
         with:
           name: ${{ github.run_number }}-sbom.json
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+        with:
+          platforms: all
+
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/python-push-to-registries.yml
+++ b/.github/workflows/python-push-to-registries.yml
@@ -101,6 +101,11 @@ jobs:
         run: |
           mv ${{ needs.generate-and-scan-application-sbom.outputs.artifact-name }}-bom.json sbom.json
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+        with:
+          platforms: all
+
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
It was noticed that OSS repositories didn't seem to be producing OSS images correctly, on digging it was spotted that these were missing the necessary QEMU setup step present in the internal versions of this workflow.  Adding this step should allow OSS repositories to generate valid multi-platform images.