### PR TITLE
Enable Trivy caching (CORE-455)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -219,6 +219,23 @@ jobs:
             mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
           fi
 
+      - name: Trivy Cache
+        id: trivy-cache
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
+
+      - name: Download Trivy Java DB
+        if: ${{ matrix.os == 'ubuntu-latest' && (steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false') }}
+        uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
+        with:
+          scan-type: image
+          cache-dir: .trivy
+
       - name: Trivy Vulnerability Scan
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: aquasecurity/trivy-action@master
@@ -228,6 +245,7 @@ jobs:
           format: json
           scan-ref: .
           exit-code: 0
+          cache-dir: .trivy
 
       - name: Upload Vulnerability Scan Results
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -247,6 +265,7 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
+          cache-dir: .trivy
 
       - name: Detect Maven version
         id: project

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -256,6 +256,22 @@ jobs:
         run: |
           echo "args=-Dgpg.skip=true" >> "$GITHUB_OUTPUT"
 
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
+
+      - name: Download Trivy Java DB
+        if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
+        uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
+        with:
+          scan-type: image
+          cache-dir: .trivy
+
       - name: Trivy Vulnerability Scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -264,6 +280,7 @@ jobs:
           format: json
           scan-ref: .
           exit-code: 0
+          cache-dir: .trivy
 
       - name: Upload Vulnerability Scan Results
         uses: actions/upload-artifact@v4
@@ -281,6 +298,7 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
+          cache-dir: .trivy
 
       - name: Detect Maven version
         id: project

--- a/.github/workflows/python-generate-image-sbom.yml
+++ b/.github/workflows/python-generate-image-sbom.yml
@@ -28,13 +28,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
+
       - name: Generate SBOM for image
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'image'
           format: 'cyclonedx'
           output: ${{ inputs.SCAN_NAME }}-bom.json
           image-ref: ${{ inputs.IMAGE_REF }}
+          cache-dir: .trivy
 
       - name: Store the SBOM
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python-scan-sbom.yml
+++ b/.github/workflows/python-scan-sbom.yml
@@ -28,6 +28,7 @@ jobs:
           scan-ref: ${{ inputs.SCAN_NAME }}-bom.json
           scan-type: 'sbom'
           scanners: 'vuln'
+          cache-dir: .trivy
 
       - name: Anchore Scan for HIGH and CRITICAL vulnerabilities
         id: anchore-scan
@@ -60,6 +61,7 @@ jobs:
           output: ${{ inputs.SCAN_NAME }}-trivy-scan-report.json
           format: 'json'
           exit-code: '0'
+          cache-dir: .trivy
 
       - name: Anchore Full Vulnerability Scan
         id: anchore-full-scan

--- a/.github/workflows/trivy-dockerfile-scan.yml
+++ b/.github/workflows/trivy-dockerfile-scan.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
+
       - name: Trivy Docker Misconfiguration Scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -34,6 +41,7 @@ jobs:
           output: trivy-docker-misconfiguration-report.json
           format: json
           exit-code: 0
+          cache-dir: .trivy
 
       - name: Upload Misconfiguration Scan Results
         uses: actions/upload-artifact@v4
@@ -50,3 +58,4 @@ jobs:
           format: table
           severity: HIGH,CRITICAL
           exit-code: 1
+          cache-dir: .trivy

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
+
       - name: Trivy Vulnerability Scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -46,6 +53,7 @@ jobs:
           output: trivy-docker-report.json
           format: json
           exit-code: 0
+          cache-dir: .trivy
 
       - name: Upload Vulnerability Scan Results
         uses: actions/upload-artifact@v4
@@ -62,6 +70,7 @@ jobs:
           format: 'cyclonedx'
           output: ${{ inputs.RELEASE_SBOM_FILE }}
           image-ref: ${{ inputs.IMAGE_REF }}
+          cache-dir: .trivy
 
       - name: Release SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
@@ -86,3 +95,4 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
+          cache-dir: .trivy

--- a/.github/workflows/vulnerability-scanning-on-repo.yml
+++ b/.github/workflows/vulnerability-scanning-on-repo.yml
@@ -64,6 +64,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}-sbom.json
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
       - name: Scan SBOM, report as table file
         uses: aquasecurity/trivy-action@master
         with:
@@ -73,6 +79,7 @@ jobs:
           scanners: 'vuln'
           format: 'table'
           output: trivy-sbom-vuln-report.txt
+          cache-dir: .trivy
       - run: cat trivy-sbom-vuln-report.txt
       - name: Attach trivy-sbom-vuln-report.txt to release
         uses: softprops/action-gh-release@v2
@@ -89,6 +96,7 @@ jobs:
           scanners: 'vuln'
           output: trivy-sbom-vuln-report.json
           format: json
+          cache-dir: .trivy
       - name: Attach trivy-sbom-vuln-report.json to release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -104,6 +112,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}-sbom.json
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
+
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
@@ -115,6 +130,7 @@ jobs:
           scanners: 'vuln'
           format: 'table'
           output: trivy-sbom-HIGH-CRITICAL-vuln-report.txt
+          cache-dir: .trivy
       - run: cat trivy-sbom-HIGH-CRITICAL-vuln-report.txt
       - name: Download artifact       
         uses: actions/download-artifact@v4
@@ -135,6 +151,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.run_number }}-sbom.json
+      - name: Trivy Cache
+        id: trivy-cache
+        uses: yogeshlonkar/trivy-cache-action@c09b68f72328987374e9daf2245707addf8910cb
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ github.workflow }}
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
@@ -146,3 +168,4 @@ jobs:
           scanners: 'vuln'
           format: 'table'
           output: trivy-sbom-HIGH-CRITICAL-vuln-report.txt
+          cache-dir: .trivy


### PR DESCRIPTION
Every workflow that uses Trivy is modified to enable Trivy DB Caching which should reduce the frequency of rate limiting errors seen when trying to download the Trivy DB files