### PR TITLE
Auto-create Maven Release PRs

### DIFF
--- a/.github/workflows/maven-github-release.yml
+++ b/.github/workflows/maven-github-release.yml
@@ -161,5 +161,14 @@ jobs:
           files: |
             **/*-bom.json
             ${{ inputs.RELEASE_FILES }}
-        
-        
+
+      - name: Open Release PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+             --base main \
+             --head release/${{ steps.project.outputs.version }} \
+             --body-file ${{ steps.release-notes.outputs.release-notes-file }} \
+             --title "Complete Release ${{ steps.project.outputs.version }}"
+


### PR DESCRIPTION
Adds a new step to the Maven GitHub Release workflow so that on successful release it will create a Release PR that completes the release process.  This avoids the need for developers to manually open said PRs and reduces the chance that these get missed.

Note no reviewers are assigned, rather we'll rely on default reviewers which are populated from `CODEOWNERS` if present which it mostly isn't currently, but something we can address over time.