### PR TITLE
fix: grype erroring with invalid sbom

### DIFF
--- a/.github/workflows/dockerhub-vulnscan-image.yml
+++ b/.github/workflows/dockerhub-vulnscan-image.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Scan Docker Image with Anchore
         id: anchore-scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v4.1.2
         with:
           image: ${{ inputs.IMAGE_NAME }}
           fail-build: true

--- a/.github/workflows/grype-image-scan.yml
+++ b/.github/workflows/grype-image-scan.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Grype Container Vulnerability Scan
         id: grype-scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v4.1.2
         with:
           image: ${{ inputs.IMAGE_REF }}
           output-format: json
@@ -49,7 +49,7 @@ jobs:
           retention-days: 30
   
       - name: Fail Build on High/Critical Vulnerabilities
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v4.1.2
         with:
           image: ${{ inputs.IMAGE_REF }}
           output-format: table

--- a/.github/workflows/python-scan-sbom.yml
+++ b/.github/workflows/python-scan-sbom.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Anchore Scan for HIGH and CRITICAL vulnerabilities
         id: anchore-scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v4.1.2
         with:
           sbom: ${{ inputs.SCAN_NAME }}-bom.json
           fail-build: true
@@ -63,7 +63,7 @@ jobs:
 
       - name: Anchore Full Vulnerability Scan
         id: anchore-full-scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v4.1.2
         with:
           sbom: ${{ inputs.SCAN_NAME }}-bom.json
           fail-build: true


### PR DESCRIPTION
Fixes an issue with grype not being able to recognise CycloneDX generated sbom as a valid one.