### PR TITLE
Make opening Maven Release PR not break build

### DIFF
--- a/.github/workflows/maven-github-release.yml
+++ b/.github/workflows/maven-github-release.yml
@@ -165,6 +165,11 @@ jobs:
       - name: Open Release PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # This could error under a few circumstances:
+        # 1 - The Developer is proactive and has already opened the PR from the release branch to main
+        # 2 - The build has been restarted due to some transient failure so the PR was previously created
+        # Therefore set continue-on-error to true for this step
+        continue-on-error: true
         run: |
           gh pr create \
              --base main \


### PR DESCRIPTION
As seen in SCG build if the developer is proactive in creating the Release PR, or it already exists for some other reason, then this breaks the build and causes artefacts to not be correctly published.  Make the Release PR step continue-on-error: true so that failures in that step are ignored.