### PR TITLE
[Minor]  Add feature flag to avoid SBOM download error on Backend runs

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -76,7 +76,13 @@ on:
         default: temurin
         description: |
           Specifies the JDK to use, defaults to temurin.
-  # Allows you to run this workflow manually from the Actions tab
+      DOWNLOAD_SBOM:
+        required: false
+        type: boolean
+        default: true
+        description: |
+          Whether to download the SBOM from the artifact. Only needed in some flows - hence being disabled so as to avoid errors.
+      # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -107,6 +113,7 @@ jobs:
       # SBOM in this fashion hence continue-on-error: true
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4
+        if: ${{ input.DOWNLOAD_SBOM }}
         continue-on-error: true
         with:
           name: ${{ github.run_number }}-sbom.json


### PR DESCRIPTION
To avoid SBOM download errors on the Back-end pipeline, add env variable (on by default) that can disable it and thus avoid confusing errors. 

![Screenshot 2024-10-10 at 12 13 24](https://github.com/user-attachments/assets/e0d29d15-c41f-4600-b881-2b1b6df7f5f9)
