### PR TITLE
ci: change trivy cache prefix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -225,7 +225,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
 
       - name: Download Trivy Java DB
         if: ${{ matrix.os == 'ubuntu-latest' && (steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -225,7 +225,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
 
       - name: Download Trivy Java DB
         if: ${{ matrix.os == 'ubuntu-latest' && (steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false') }}

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -261,7 +261,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
 
       - name: Download Trivy Java DB
         if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -261,7 +261,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
 
       - name: Download Trivy Java DB
         if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}

--- a/.github/workflows/python-generate-image-sbom.yml
+++ b/.github/workflows/python-generate-image-sbom.yml
@@ -33,7 +33,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
 
       - name: Generate SBOM for image
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/python-generate-image-sbom.yml
+++ b/.github/workflows/python-generate-image-sbom.yml
@@ -33,7 +33,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
 
       - name: Generate SBOM for image
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/trivy-dockerfile-scan.yml
+++ b/.github/workflows/trivy-dockerfile-scan.yml
@@ -31,7 +31,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
 
       - name: Trivy Docker Misconfiguration Scan
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/trivy-dockerfile-scan.yml
+++ b/.github/workflows/trivy-dockerfile-scan.yml
@@ -31,7 +31,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
 
       - name: Trivy Docker Misconfiguration Scan
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -38,7 +38,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
 
       - name: Trivy Vulnerability Scan
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -38,7 +38,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
 
       - name: Trivy Vulnerability Scan
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/vulnerability-scanning-on-repo.yml
+++ b/.github/workflows/vulnerability-scanning-on-repo.yml
@@ -73,7 +73,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
       - name: Scan SBOM, report as table file
         uses: aquasecurity/trivy-action@master
         with:
@@ -122,7 +122,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
@@ -160,7 +160,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository }}
+          prefix: ${{ github.repository_id }}
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/vulnerability-scanning-on-repo.yml
+++ b/.github/workflows/vulnerability-scanning-on-repo.yml
@@ -73,7 +73,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
       - name: Scan SBOM, report as table file
         uses: aquasecurity/trivy-action@master
         with:
@@ -122,7 +122,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
@@ -160,7 +160,7 @@ jobs:
         uses: yogeshlonkar/trivy-cache-action@v0.1.8
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.workflow }}
+          prefix: ${{ github.repository }}
       - name: Test SBOM (HIGH,CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
Changing trivy cache key prefix to address intermittent Trivy scan failures in the workflows.

See [here](https://github.com/Telicent-io/pipeline-entity-extraction/actions/runs/11274705737/job/31355224725) for example.