### PR TITLE
feat: cve ignore for build images

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -93,6 +93,15 @@ on:
         default: true
         description: |
           Set `false` to avoid trying to download SBOM artifacts (and if it fails, avoid "sbom not found" errors). Used by certain workflows that don't need to download SBOMs
+      TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE:
+        required: false
+        type: string
+        description: Name of trivy ignore file. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
+      GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE:
+        required: false
+        type: string
+        description: Path to custom grype yaml file. NEVER use .grype.yaml, must be non-default filename. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
+    
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -121,7 +130,6 @@ jobs:
         if: ${{ inputs.USES_MAVEN }}
         run: |
           mvn verify --batch-mode -DskipTests -Dgpg.skip=true
-
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4.1.8
         if: ${{ inputs.DOWNLOAD_SBOM }}
@@ -215,6 +223,7 @@ jobs:
     with:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
+      PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.PACKAGE_DIRECTORY }}/${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE }}
   grype-scan-image:
     needs: build
     uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@main
@@ -225,3 +234,4 @@ jobs:
     with:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
+      PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE: ${{ inputs.PACKAGE_DIRECTORY }}/${{ inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE }}

--- a/.github/workflows/grype-image-scan.yml
+++ b/.github/workflows/grype-image-scan.yml
@@ -13,6 +13,10 @@ on:
         description: |
           Specifies the full image reference (repository, name and tag) for an image you wish to scan.
         required: true
+      PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE:
+        required: false
+        type: string
+        description: Path to custom grype yaml file. NEVER use .grype.yaml, must be non-default filename. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -26,6 +30,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1
+
+      - name: Maybe setup custom Grype config
+        if: ${{ inputs.PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE != '' }}
+        run: cp ${{ inputs.PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE }} ./.grype.yaml
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -13,7 +13,11 @@ on:
         description: |
           Specifies the full image reference (repository, name and tag) for an image you wish to scan.
         required: true
-
+      PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE:
+        required: false
+        type: string
+        description: Only allowed for BUILD image, MUST NOT be used with DEPLOY image. Full relative path to trivy ignore file.
+    
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -80,6 +84,7 @@ jobs:
           cache-dir: .trivy
           # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
           cache: false
+          trivyignores: ${{ inputs.PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE }}
 
       - name: Upload Vulnerability Scan Results
         uses: actions/upload-artifact@v4.4.3
@@ -99,6 +104,7 @@ jobs:
           cache-dir: .trivy
           # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
           cache: false
+          trivyignores: ${{ inputs.PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE }}
 
       - name: Release SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
@@ -129,3 +135,4 @@ jobs:
           cache-dir: .trivy
           # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
           cache: false
+          trivyignores: ${{ inputs.PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE }}


### PR DESCRIPTION
Despite dragging my feet hoping docker node would fix their CVE - they have not.
(I'm going to side step the issue _for now_)

If we have CVEs in the _build_ image, they can be easily explained away. So it is worth turning off certain CVEs - only in build images.

Obviously this is relying on convention/documentation to ensure people don't ignore important CVEs, not ideal but not terrible.