### PR TITLE
Update work flow for quicker front end builds and scanning 

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,6 +231,9 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
+          cache-to: type=local,src=/tmp/images
+      - name: See what is in the tmp folder
+        run: ls /tmp/images
       - name: Save image
         run: echo '$FILENAME' && docker save --output /tmp/${{ env.FILENAME }} ${{ env.IMAGE_NAME }} && ls /tmp
         if: ${{ inputs.DRY_RUN }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -112,7 +112,11 @@ on:
         required: false
         type: string
         description: Path to custom grype yaml file. NEVER use .grype.yaml, must be non-default filename. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
-
+      DRY_RUN:
+        required: false
+        type: boolean
+        default: false
+        description: Input flag to test the build but not push to the registry
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -220,7 +224,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           # Dependabot triggered PRs don't have credentials to push images
-          push: ${{ github.actor != 'dependabot[bot]' }}
+          push: ${{ github.actor != 'dependabot[bot]' && !inputs.DRY_RUN }}
           context: ${{ inputs.PATH }}
           file: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }} # NOTE: relative path (inputs.PATH defaults to '.')
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -155,7 +155,7 @@ jobs:
         if: ${{ inputs.BUILD_ARTIFACT }}
         with:
           name: ${{ inputs.BUILD_ARTIFACT }}
-          path: ${{ inputs.BUILD_ARTIFACT }}/
+          path: ${{ inputs.PATH}}/${{ inputs.BUILD_ARTIFACT }}/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,6 +231,10 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
+          outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar' ?? '' }}
+      - name: Save image
+        run: docker save --output /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }} && ls /tmp
+        if: ${{ inputs.DRY_RUN }}
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -261,6 +261,7 @@ jobs:
     # an image for it to pull down and scan
     if: ${{ github.actor != 'dependabot[bot]' }}
     with:
+      DRY_RUN: ${{ inputs.DRY_RUN }}
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
       PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE) || '' }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,7 +231,7 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          output: ${{inputs.DRY_RUN && "type=docker,dest=/tmp/${{ steps.meta.outputs.tags[0] }}.tar" }}
+          output: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/${{ steps.meta.outputs.tags[0] }}.tar' || '' }}
       - name: Check docker export exists
         run: ls /tmp
       - name: Upload Docker Image

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,6 +231,15 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
+          output: ${{inputs.DRY_RUN && "type=docker,dest=/tmp/${{ steps.meta.outputs.tags[0] }}.tar" }}
+      - name: Check docker export exists
+        run: ls /tmp
+      - name: Upload Docker Image
+        if: ${{ inputs.DRY_RUN }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.tags[0] }}
+          path: /tmp/${{ steps.meta.outputs.tags[0] }}.tar
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,7 +231,7 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar' ?? '' }}
+          outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar' || '' }}
       - name: Save image
         run: docker save --output /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }} && ls /tmp
         if: ${{ inputs.DRY_RUN }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,15 +231,7 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          cache-to: type=local,src=/tmp/images
-      - name: See what is in the tmp folder
-        run: ls /tmp/images
-      - name: Save image
-        run: echo '$FILENAME' && docker save --output /tmp/${{ env.FILENAME }} ${{ env.IMAGE_NAME }} && ls /tmp
-        if: ${{ inputs.DRY_RUN }}
-        env:
-          FILENAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
-          IMAGE_NAME: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
+          load: ${{ inputs.DRY_RUN }}
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -246,7 +246,7 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          outputs: type=local,dest=/tmp/docker
+          outputs: type=docker,dest=/tmp/docker/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar
       - name: View outputs
         if: ${{ inputs.DRY_RUN }}
         run: ls /tmp/docker

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -246,10 +246,16 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          outputs: type=docker,dest=/tmp/docker/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar
+          outputs: type=docker,dest=/tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
       - name: View outputs
         if: ${{ inputs.DRY_RUN }}
-        run: ls /tmp/docker
+        run: ls /tmp
+      - name: Upload Docker image
+        if: ${{ input.DRY_RUN }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
+          path: /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -20,6 +20,11 @@ on:
         type: string
         description: |
           The name of the Dockerfile to build the image from.  This is relative to the PATH input
+      BUILD_ARTIFACT:
+        required: false
+        type: string
+        description: |
+          Artifact used as part of the Docker build.
       PATH:
         type: string
         description: |
@@ -82,6 +87,12 @@ on:
         default: true
         description: |
           Set `false` to avoid adding mutable tags like `latest` and `development` e.g. if image registry has mutable tags disabled, and it will 400s when given mutable tags
+      ENABLE_BUILDKIT_CACHE:
+        required: false
+        default: true
+        type: boolean
+        description: |
+          Whether the docker buildkit cache is required.
       PACKAGE_DIRECTORY:
         required: false
         type: string
@@ -101,7 +112,7 @@ on:
         required: false
         type: string
         description: Path to custom grype yaml file. NEVER use .grype.yaml, must be non-default filename. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
-    
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -124,19 +135,27 @@ jobs:
           distribution: ${{ inputs.JDK }}
           cache: maven
 
-      # NB - Assumption here is that this workflow has been called after the Maven workflow has been called so the 
+      # NB - Assumption here is that this workflow has been called after the Maven workflow has been called so the
       #      Maven Cache already has all our dependencies present in it and tests have already passed
       - name: Quick Maven Build
         if: ${{ inputs.USES_MAVEN }}
         run: |
           mvn verify --batch-mode -DskipTests -Dgpg.skip=true
+
       - name: Get SBOM from artifact
         uses: actions/download-artifact@v4.1.8
         if: ${{ inputs.DOWNLOAD_SBOM }}
         continue-on-error: true
         with:
           name: ${{ github.run_number }}${{ inputs.PACKAGE_DIRECTORY != '.' && format('.{0}', inputs.PACKAGE_DIRECTORY) || '' }}.sbom.json
-          path: ${{ inputs.PATH }} 
+          path: ${{ inputs.PATH }}
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        if: ${{ inputs.BUILD_ARTIFACT }}
+        with:
+          name: ${{ inputs.BUILD_ARTIFACT }}
+          path: ${{ inputs.BUILD_ARTIFACT }}/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
@@ -149,6 +168,7 @@ jobs:
 
       - name: Enable buildkit cache
         uses: actions/cache@v4.1.1
+        if: ${{ inputs.ENABLE_BUILDKIT_CACHE }}
         with:
           path: /tmp/buildkit-cache/buildkit-state.tar
           key: ${{ runner.os }}-buildkit-${{ github.sha }}
@@ -157,6 +177,7 @@ jobs:
 
       - name: Load buildkit state from cache
         uses: dashevo/gh-action-cache-buildkit-state@v1.0.3
+        if: ${{ inputs.ENABLE_BUILDKIT_CACHE }}
         with:
           builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
           cache-path: /tmp/buildkit-cache

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -116,7 +116,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: Input flag to test the build but not push to the registry
+        description: Input flag to test the build but not push to the registry (will currently fail scan, to be done)
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -231,15 +231,6 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/${{ steps.meta.outputs.tags[0] }}.tar' || '' }}
-      - name: Check docker export exists
-        run: ls /tmp && echo /tmp/${{ steps.meta.outputs.tags[0] }}.tar
-      - name: Upload Docker Image
-        if: ${{ inputs.DRY_RUN }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.meta.outputs.tags[0] }}
-          path: /tmp/${{ steps.meta.outputs.tags[0] }}.tar
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -251,7 +251,7 @@ jobs:
         if: ${{ inputs.DRY_RUN }}
         run: ls /tmp
       - name: Upload Docker image
-        if: ${{ input.DRY_RUN }}
+        if: ${{ inputs.DRY_RUN }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,9 +231,9 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          output: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/${{ steps.meta.outputs.tags[0] }}.tar' || '' }}
+          outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/${{ steps.meta.outputs.tags[0] }}.tar' || '' }}
       - name: Check docker export exists
-        run: ls /tmp
+        run: ls /tmp && echo /tmp/${{ steps.meta.outputs.tags[0] }}.tar
       - name: Upload Docker Image
         if: ${{ inputs.DRY_RUN }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -189,6 +189,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0
+        if: ${{ !inputs.DRY_RUN }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -220,11 +221,24 @@ jobs:
       - name: Build, tag, and push image to authenticated docker registry
         id: build-images
         uses: docker/build-push-action@v6.9.0
+        if: ${{ !inputs.DRY_RUN }}
         with:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           # Dependabot triggered PRs don't have credentials to push images
           push: ${{ github.actor != 'dependabot[bot]' && !inputs.DRY_RUN }}
+          context: ${{ inputs.PATH }}
+          file: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }} # NOTE: relative path (inputs.PATH defaults to '.')
+          tags: ${{ steps.meta.outputs.tags }}
+          target: ${{ inputs.TARGET }}
+          build-args: |
+            ${{ inputs.BUILD_ARGS }}
+      - name: Build and tag image
+        uses: docker/build-push-action@v6.9.0
+        if: ${{ inputs.DRY_RUN }}
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          # Dependabot triggered PRs don't have credentials to push images
           context: ${{ inputs.PATH }}
           file: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }} # NOTE: relative path (inputs.PATH defaults to '.')
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -254,7 +254,7 @@ jobs:
         if: ${{ inputs.DRY_RUN }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
+          name: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
           path: /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
 
   scan-dockerfile-configuration:

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -235,6 +235,7 @@ jobs:
             ${{ inputs.BUILD_ARGS }}
       - name: Build and tag image
         uses: docker/build-push-action@v6.9.0
+        id: build-local-image
         if: ${{ inputs.DRY_RUN }}
         with:
           builder: ${{ steps.buildx.outputs.name }}
@@ -245,7 +246,10 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          load: ${{ inputs.DRY_RUN }}
+          outputs: type=local,dest=/tmp/docker
+      - name: View outputs
+        if: ${{ inputs.DRY_RUN }}
+        run: ls /tmp/docker
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -233,7 +233,7 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-      - name: Build and tag image
+      - name: Build Docker Tarball
         uses: docker/build-push-action@v6.9.0
         id: build-local-image
         if: ${{ inputs.DRY_RUN }}
@@ -265,25 +265,25 @@ jobs:
 
   trivy-scan-image:
     needs: build
-    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@update-workflow-for-docker-with-build-artifact
+    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan
     if: ${{ github.actor != 'dependabot[bot]' }}
     with:
-      DRY_RUN: ${{ inputs.DRY_RUN }}
+      IMAGE_FROM_ARTIFACT: ${{ inputs.DRY_RUN }}
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
       PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE) || '' }}
   grype-scan-image:
     needs: build
-    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@update-workflow-for-docker-with-build-artifact
+    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@main
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan
     if: ${{ github.actor != 'dependabot[bot]' }}
     with:
-      DRY_RUN: ${{ inputs.DRY_RUN }}
+      IMAGE_FROM_ARTIFACT: ${{ inputs.DRY_RUN }}
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
       PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE: ${{ inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE) || '' }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -283,6 +283,7 @@ jobs:
     # an image for it to pull down and scan
     if: ${{ github.actor != 'dependabot[bot]' }}
     with:
+      DRY_RUN: ${{ inputs.DRY_RUN }}
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
       PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE: ${{ inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE) || '' }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -116,7 +116,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: Input flag to test the build but not push to the registry (will currently fail scan, to be done)
+        description: Flag to test the build and scan without pushing to the registry
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -232,10 +232,11 @@ jobs:
           build-args: |
             ${{ inputs.BUILD_ARGS }}
       - name: Save image
-        run: docker save --output /tmp/$filename && ls /tmp
+        run: echo '$FILENAME' && docker save --output /tmp/${{ env.FILENAME }} ${{ env.IMAGE_NAME }} && ls /tmp
         if: ${{ inputs.DRY_RUN }}
         env:
-          filename: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
+          FILENAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
+          IMAGE_NAME: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -177,7 +177,7 @@ jobs:
           path: /tmp/buildkit-cache/buildkit-state.tar
           key: ${{ runner.os }}-buildkit-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildkit-
+            ${{ runner.os }}-buildkit-${{ github.sha }}
 
       - name: Load buildkit state from cache
         uses: dashevo/gh-action-cache-buildkit-state@v1.0.3

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -255,7 +255,7 @@ jobs:
 
   trivy-scan-image:
     needs: build
-    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@update-workflow-for-docker-with-build-artifact
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -231,7 +231,6 @@ jobs:
           target: ${{ inputs.TARGET }}
           build-args: |
             ${{ inputs.BUILD_ARGS }}
-          outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar' || '' }}
       - name: Save image
         run: docker save --output /tmp/$filename && ls /tmp
         if: ${{ inputs.DRY_RUN }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -233,10 +233,10 @@ jobs:
             ${{ inputs.BUILD_ARGS }}
           outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar' || '' }}
       - name: Save image
-        run: ${{ docker save --output /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }} && ls /tmp }}
+        run: docker save --output /tmp/$filename && ls /tmp
         if: ${{ inputs.DRY_RUN }}
-        # env:
-        #   file
+        env:
+          filename: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -277,7 +277,7 @@ jobs:
       PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE) || '' }}
   grype-scan-image:
     needs: build
-    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@main
+    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@update-workflow-for-docker-with-build-artifact
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -233,8 +233,10 @@ jobs:
             ${{ inputs.BUILD_ARGS }}
           outputs: ${{ inputs.DRY_RUN && 'type=docker,dest=/tmp/telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}.tar' || '' }}
       - name: Save image
-        run: docker save --output /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }} && ls /tmp
+        run: ${{ docker save --output /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }} && ls /tmp }}
         if: ${{ inputs.DRY_RUN }}
+        # env:
+        #   file
 
   scan-dockerfile-configuration:
     uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -155,7 +155,7 @@ jobs:
         if: ${{ inputs.BUILD_ARTIFACT }}
         with:
           name: ${{ inputs.BUILD_ARTIFACT }}
-          path: ${{ inputs.PATH}}/${{ inputs.BUILD_ARTIFACT }}/
+          path: ${{ inputs.PATH }}/${{ inputs.BUILD_ARTIFACT }}/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0

--- a/.github/workflows/grype-image-scan.yml
+++ b/.github/workflows/grype-image-scan.yml
@@ -17,11 +17,13 @@ on:
         required: false
         type: string
         description: Path to custom grype yaml file. NEVER use .grype.yaml, must be non-default filename. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
-      DRY_RUN:
+      IMAGE_FROM_ARTIFACT:
         required: false
         default: false
         type: boolean
-        description: Flag to download an artifact image (named as ${SCAN_NAME}.tar) and scan
+        description: |
+          Scan a Docker image tar stored as an artifact (name must be ${SCAN_NAME}.tar), rather
+          than an image stored in a remote repository
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -41,20 +43,20 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0
-        if: ${{ !inputs.DRY_RUN }}
+        if: ${{ !inputs.IMAGE_FROM_ARTIFACT }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Download image artifact
         uses: actions/download-artifact@v4
-        if: ${{ inputs.DRY_RUN }}
+        if: ${{ inputs.IMAGE_FROM_ARTIFACT }}
         with:
           name: ${{ inputs.SCAN_NAME }}.tar
           path: .
 
       - name: Load docker image for dry run scans
-        if: ${{ inputs.DRY_RUN }}
+        if: ${{ inputs.IMAGE_FROM_ARTIFACT }}
         run: docker load --input ${{ inputs.SCAN_NAME }}.tar
 
       - name: Grype Container Vulnerability Scan

--- a/.github/workflows/grype-image-scan.yml
+++ b/.github/workflows/grype-image-scan.yml
@@ -17,7 +17,10 @@ on:
         required: false
         type: string
         description: Path to custom grype yaml file. NEVER use .grype.yaml, must be non-default filename. Only allowed for BUILD image, MUST NOT be used with DEPLOY images.
-
+      DRY_RUN:
+        required: false
+        default: false
+        type: boolean
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -37,9 +40,21 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0
+        if: ${{ !inputs.DRY_RUN }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        if: ${{ inputs.DRY_RUN }}
+        with:
+          name: ${{ inputs.SCAN_NAME }}.tar
+          path: .
+
+      - name: Load docker image for dry run scans
+        if: ${{ inputs.DRY_RUN }}
+        run: docker load --input ${{ inputs.SCAN_NAME }}.tar
 
       - name: Grype Container Vulnerability Scan
         id: grype-scan
@@ -55,7 +70,7 @@ jobs:
           name: grype-docker-report-${{ inputs.SCAN_NAME }}
           path: ${{ steps.grype-scan.outputs.json }}
           retention-days: 30
-  
+
       - name: Fail Build on High/Critical Vulnerabilities
         uses: anchore/scan-action@v4.1.2
         with:

--- a/.github/workflows/grype-image-scan.yml
+++ b/.github/workflows/grype-image-scan.yml
@@ -21,6 +21,7 @@ on:
         required: false
         default: false
         type: boolean
+        description: Flag to download an artifact image (named as ${SCAN_NAME}.tar) and scan
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -40,30 +40,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Set up Docker buildx
-        id: buildx
-        if: ${{ inputs.DRY_RUN }}
-        uses: docker/setup-buildx-action@v3.7.1
 
-      - name: Enable buildkit cache
-        uses: actions/cache@v4.1.1
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         if: ${{ inputs.DRY_RUN }}
         with:
-          path: /tmp/buildkit-cache/buildkit-state.tar
-          key: ${{ runner.os }}-buildkit-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildkit-${{ github.sha }}
+          name: ${{ inputs.SCAN_NAME }}.tar
+          path: ${{ inputs.IMAGE_REF }}.tar
 
-      - name: Load buildkit state from cache
-        uses: dashevo/gh-action-cache-buildkit-state@v1.0.3
+      - name: Load docker image for dry run scans
         if: ${{ inputs.DRY_RUN }}
-        with:
-          builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
-          cache-path: /tmp/buildkit-cache
-          cache-max-size: 3g
-
-      - name: Test recovery of artifact
-        run: docker image inspect ${{ inputs.IMAGE_REF }}
+        run: docker load --input ${{ inputs.IMAGE_REF }}.tar
 
       - name: Trivy Cache
         id: trivy-cache

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -42,7 +42,25 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set up Docker buildx
         id: buildx
+        if: ${{ inputs.DRY_RUN }}
         uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Enable buildkit cache
+        uses: actions/cache@v4.1.1
+        if: ${{ inputs.DRY_RUN }}
+        with:
+          path: /tmp/buildkit-cache/buildkit-state.tar
+          key: ${{ runner.os }}-buildkit-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-
+
+      - name: Load buildkit state from cache
+        uses: dashevo/gh-action-cache-buildkit-state@v1.0.3
+        if: ${{ inputs.DRY_RUN }}
+        with:
+          builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
+          cache-path: /tmp/buildkit-cache
+          cache-max-size: 3g
 
       - name: Test recovery of artifact
         run: docker image inspect ${{ inputs.IMAGE_REF }}

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -17,7 +17,10 @@ on:
         required: false
         type: string
         description: Only allowed for BUILD image, MUST NOT be used with DEPLOY image. Full relative path to trivy ignore file.
-    
+      DRY_RUN:
+        required: false
+        default: false
+        type: boolean
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -33,9 +36,16 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0
+        if: ${{ !inputs.DRY_RUN }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Test recovery of artifact
+        run: docker image inspect ${{ inputs.IMAGE_REF }}
 
       - name: Trivy Cache
         id: trivy-cache
@@ -97,8 +107,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: aquasecurity/trivy-action@master
         with:
-          scan-type: 'image'
-          format: 'cyclonedx'
+          scan-type: "image"
+          format: "cyclonedx"
           output: trivy-image-scan-sbom-${{ inputs.SCAN_NAME }}.json
           image-ref: ${{ inputs.IMAGE_REF }}
           cache-dir: .trivy

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -41,16 +41,16 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Download build artifact
+      - name: Download image artifact
         uses: actions/download-artifact@v4
         if: ${{ inputs.DRY_RUN }}
         with:
           name: ${{ inputs.SCAN_NAME }}.tar
-          path: ${{ inputs.IMAGE_REF }}.tar
+          path: .
 
       - name: Load docker image for dry run scans
         if: ${{ inputs.DRY_RUN }}
-        run: docker load --input ${{ inputs.IMAGE_REF }}.tar
+        run: docker load --input ${{ inputs.SCAN_NAME }}.tar
 
       - name: Trivy Cache
         id: trivy-cache

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -17,11 +17,13 @@ on:
         required: false
         type: string
         description: Only allowed for BUILD image, MUST NOT be used with DEPLOY image. Full relative path to trivy ignore file.
-      DRY_RUN:
+      IMAGE_FROM_ARTIFACT:
         required: false
         default: false
         type: boolean
-        description: Flag to download an artifact image (named as ${SCAN_NAME}.tar) and scan
+        description: |
+          Scan a Docker image tar stored as an artifact (name must be ${SCAN_NAME}.tar), rather
+          than an image stored in a remote repository
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -37,20 +39,20 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0
-        if: ${{ !inputs.DRY_RUN }}
+        if: ${{ !inputs.IMAGE_FROM_ARTIFACT }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Download image artifact
         uses: actions/download-artifact@v4
-        if: ${{ inputs.DRY_RUN }}
+        if: ${{ inputs.IMAGE_FROM_ARTIFACT }}
         with:
           name: ${{ inputs.SCAN_NAME }}.tar
           path: .
 
       - name: Load docker image for dry run scans
-        if: ${{ inputs.DRY_RUN }}
+        if: ${{ inputs.IMAGE_FROM_ARTIFACT }}
         run: docker load --input ${{ inputs.SCAN_NAME }}.tar
 
       - name: Trivy Cache

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -52,7 +52,7 @@ jobs:
           path: /tmp/buildkit-cache/buildkit-state.tar
           key: ${{ runner.os }}-buildkit-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildkit-
+            ${{ runner.os }}-buildkit-${{ github.sha }}
 
       - name: Load buildkit state from cache
         uses: dashevo/gh-action-cache-buildkit-state@v1.0.3

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -21,6 +21,7 @@ on:
         required: false
         default: false
         type: boolean
+        description: Flag to download an artifact image (named as ${SCAN_NAME}.tar) and scan
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
This change bring in the ability to run the same build flow where frontend and javascript code can be built in the CI and then the build artifacts are built into the container. This has significantly reduced the build time within the closed source apps (in one case from an hour to approx. 12 minutes) including scanning. 

A second change in this PR allows for the option to "dry run" the build of the containers, so that the workflow can build and then scan without pushing to Docker. This has only been test with the frontend app, but should work for other docker builds and should also not impact any existing workflows. 

NB: I will be squashing before I merge, got bored with one line change commits to try things out. 