### PR TITLE
fix: Option to make Grype only error if fix is available

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -283,7 +283,7 @@ jobs:
       PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE) || '' }}
   grype-scan-image:
     needs: build
-    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@main
+    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@TELFE-528/grype-only-fixed
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -117,6 +117,12 @@ on:
         type: boolean
         default: false
         description: Flag to test the build and scan without pushing to the registry
+      GRYPE_SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE:
+        required: false
+        default: false
+        type: boolean
+        description: |
+          Sets --only-fixed flag for Grype
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -287,3 +293,4 @@ jobs:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
       PATH_TO_GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE: ${{ inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE) || '' }}
+      SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE: ${{ inputs.GRYPE_SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE }}

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -283,7 +283,7 @@ jobs:
       PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE) || '' }}
   grype-scan-image:
     needs: build
-    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@TELFE-528/grype-only-fixed
+    uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@main
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan

--- a/.github/workflows/grype-image-scan.yml
+++ b/.github/workflows/grype-image-scan.yml
@@ -24,6 +24,12 @@ on:
         description: |
           Scan a Docker image tar stored as an artifact (name must be ${SCAN_NAME}.tar), rather
           than an image stored in a remote repository
+      SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE:
+        required: false
+        default: false
+        type: boolean
+        description: |
+          Sets --only-fixed flag
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -81,3 +87,4 @@ jobs:
           output-format: table
           severity-cutoff: high
           fail-build: true
+          only-fixed: ${{ inputs.SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE }}


### PR DESCRIPTION
Option to make Grype only error if fix is available 
* Option defaults to false
* Setting to true brings Grype inline with Trivvy

# Test


* before option: https://github.com/telicent-oss/telicent-access/actions/runs/13197098865 Fails correct
* option is true: https://github.com/telicent-oss/telicent-access/actions/runs/13200569330 Passes
* Once merged will run:
	* option is false: https://github.com/telicent-oss/telicent-access/actions/runs/13202761299 (should run and fail once merged) 🚧 
	
	
🚨 **THIS OPTION WON"T BE USED BY ANY CODE IN MAIN**🚨 