### PR TITLE
Initial adoption of Telicent Trivy action (TELDEVOPS-591)

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -264,14 +264,14 @@ jobs:
           path: /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
 
   scan-dockerfile-configuration:
-    uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@TELDEVOPS-591
+    uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main
     with:
       DOCKERFILE: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }} # NOTE: relative path (inputs.PATH defaults to '.')
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
 
   trivy-scan-image:
     needs: build
-    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@TELDEVOPS-591
+    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan

--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -264,14 +264,14 @@ jobs:
           path: /tmp/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar
 
   scan-dockerfile-configuration:
-    uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@main
+    uses: Telicent-oss/shared-workflows/.github/workflows/trivy-dockerfile-scan.yml@TELDEVOPS-591
     with:
       DOCKERFILE: ${{ inputs.PATH }}/${{ inputs.DOCKERFILE }} # NOTE: relative path (inputs.PATH defaults to '.')
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
 
   trivy-scan-image:
     needs: build
-    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/trivy-image-scan.yml@TELDEVOPS-591
     secrets: inherit
     # Since Dependabot builds can't push an image we skip the scan workflow because there won't be
     # an image for it to pull down and scan
@@ -281,6 +281,7 @@ jobs:
       IMAGE_REF: telicent/${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}:${{ github.sha }}
       SCAN_NAME: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}
       PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: ${{ inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE != '' && format('{0}/{1}', inputs.PACKAGE_DIRECTORY, inputs.TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE) || '' }}
+      USES_JAVA: ${{ inputs.USES_MAVEN }}
   grype-scan-image:
     needs: build
     uses: Telicent-oss/shared-workflows/.github/workflows/grype-image-scan.yml@main

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -225,80 +225,15 @@ jobs:
             mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -P-${{ inputs.DOCKER_PROFILE }} ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
           fi
 
-      - name: Trivy Cache
-        id: trivy-cache
+      - name: Trivy Vulnerability Scanning
+        id: trivy-scan
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: yogeshlonkar/trivy-cache-action@v0.1.8
+        uses: telicent-oss/trivy-action@v1
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository_id }}
-
-      - name: Download Trivy Java DB
-        if: ${{ matrix.os == 'ubuntu-latest' && (steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false') }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1
-        with:
-          scan-type: image
-          timeout: 10m0s
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Download Trivy Vulnerability DB
-        if: ${{ matrix.os == 'ubuntu-latest' && (steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false') }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_DB_ONLY: true
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2
-        with:
-          scan-type: image
-          timeout: 10m0s
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Trivy Vulnerability Scan
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "fs"
-          output: trivy-report.json
-          format: json
+          scan-type: fs
+          scan-name: maven
           scan-ref: .
-          exit-code: 0
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Upload Vulnerability Scan Results
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: trivy-report
-          path: trivy-report.json
-          retention-days: 30
-
-      - name: Fail build on High/Criticial Vulnerabilities
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "fs"
-          format: table
-          scan-ref: .
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: 1
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
 
       - name: Detect Maven version
         id: project

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -256,76 +256,14 @@ jobs:
         run: |
           echo "args=-Dgpg.skip=true" >> "$GITHUB_OUTPUT"
 
-      - name: Trivy Cache
-        id: trivy-cache
-        uses: yogeshlonkar/trivy-cache-action@v0.1.8
+      - name: Trivy Vulnerability Scanning
+        id: trivy-scan
+        uses: telicent-oss/trivy-action@v1
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository_id }}
-
-      - name: Download Trivy Java DB
-        if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1
-        with:
-          scan-type: image
-          timeout: 10m0s
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Download Trivy Vulnerability DB
-        if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_DB_ONLY: true
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2
-        with:
-          scan-type: image
-          timeout: 10m0s # default 5m
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Trivy Vulnerability Scan
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "fs"
-          output: trivy-report.json
-          format: json
+          scan-type: fs
+          scan-name: maven
           scan-ref: .
-          exit-code: 0
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Upload Vulnerability Scan Results
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: trivy-report
-          path: trivy-report.json
-          retention-days: 30
-
-      - name: Fail build on High/Criticial Vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "fs"
-          format: table
-          scan-ref: .
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: 1
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
 
       - name: Detect Maven version
         id: project

--- a/.github/workflows/trivy-dockerfile-scan.yml
+++ b/.github/workflows/trivy-dockerfile-scan.yml
@@ -26,52 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.1
 
-      - name: Trivy Cache
-        id: trivy-cache
-        uses: yogeshlonkar/trivy-cache-action@v0.1.8
+      - name: Trivy Vulnerability Scanning
+        id: trivy-scan
+        uses: telicent-oss/trivy-action@v1
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository_id }}
-
-      - name: Download Trivy Vulnerability DB
-        if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_DB_ONLY: true
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2
-        with:
-          timeout: 10m0s
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Trivy Docker Misconfiguration Scan
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "config"
+          scan-type: config
+          scan-name: docker-misconfiguration-${{ inputs.SCAN_NAME }}
           scan-ref: ${{ inputs.DOCKERFILE }}
-          severity: HIGH,CRITICAL
-          output: trivy-docker-misconfiguration-report.json
-          format: json
-          exit-code: 0
-          cache-dir: .trivy
-
-      - name: Upload Misconfiguration Scan Results
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: trivy-docker-misconfiguration-report-${{ inputs.SCAN_NAME }}
-          path: trivy-docker-misconfiguration-report.json
-          retention-days: 30
-  
-      - name: Fail Build on High/Critical Misconfigurations
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: "config"
-          scan-ref: ${{ inputs.DOCKERFILE }}
-          format: table
-          severity: HIGH,CRITICAL
-          exit-code: 1
-          cache-dir: .trivy

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -30,6 +30,13 @@ on:
         type: boolean
         description: |
           Sets ignore-unfixed flag
+      USES_JAVA:
+        required: false
+        default: false
+        type: boolean
+        description: |
+          Indicates whether the image includes Java artifacts, we need to know this in order to determine which Trivy
+          vulnerability databases to obtain.
           
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -62,61 +69,15 @@ jobs:
         if: ${{ inputs.IMAGE_FROM_ARTIFACT }}
         run: docker load --input ${{ inputs.SCAN_NAME }}.tar
 
-      - name: Trivy Cache
-        id: trivy-cache
-        uses: yogeshlonkar/trivy-cache-action@v0.1.8
+      - name: Trivy Vulnerability Scanning
+        id: trivy-scan
+        uses: telicent-oss/trivy-action@v1
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: ${{ github.repository_id }}
-
-      - name: Download Trivy Java DB
-        if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1
-        with:
           scan-type: image
-          timeout: 10m0s
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Download Trivy Vulnerability DB
-        if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DOWNLOAD_DB_ONLY: true
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2
-        with:
-          scan-type: image
-          timeout: 10m0s
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-
-      - name: Trivy Vulnerability Scan
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "image"
-          image-ref: ${{ inputs.IMAGE_REF }}
-          output: trivy-docker-report.json
-          format: json
-          exit-code: 0
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-          trivyignores: ${{ inputs.PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE }}
-
-      - name: Upload Vulnerability Scan Results
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: trivy-docker-report-${{ inputs.SCAN_NAME }}
-          path: trivy-docker-report.json
-          retention-days: 30
+          scan-name: docker-${{ inputs.SCAN_NAME }}
+          scan-ref: ${{ inputs.IMAGE_REF }}
+          uses-java: ${{ inputs.USES_JAVA }}
 
       - name: Generate SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
@@ -143,7 +104,7 @@ jobs:
         uses: softprops/action-gh-release@v2.0.8
         with:
           files: |
-            trivy-docker-report.json
+            ${{ steps.trivy-scan.outputs.scan-results-file }}
 
       - name: Fail Build on High/Critical Vulnerabilities
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
This is the initial conversion of some of the shared workflows to use the new Telicent Trivy action which allows simplyfying chunks of the existing shared workflows to a single step.  Due to the reductive nature of this PR you may find it best viewed using Split rather than Unified diff mode.

Note I have intentionally limited this change to the existing usages that are primarily relevant for the Platform team, though some of the common Docker workflows are changed which will affect other teams (but hopefully don't break anything!).  I expect that other teams may want to adapt their workflows to adopt this in the future but didn't want to try and do that for you in one giant PR.  Plus there are some usages that might require enhancements to the new action before they can be switched over.

Example job runs with this in place:

- https://github.com/telicent-oss/jwt-servlet-auth/actions/runs/14085865325 - A Maven only build
- https://github.com/telicent-oss/rdf-abac-evaluator/actions/runs/14103511187 - A Maven and Docker build

Where we can see the improved Trivy outputs in the job summary, and more distinct naming of the generated Trivy report artifacts.

# Outstanding Work

- [x] Needs to pin all `@TELDEVOPS-591` references back to `@main` before merging