### PR TITLE
[CORE-754] Adding Jacoco Code Coverage Reports as artifacts for the build.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -311,7 +311,9 @@ jobs:
         uses: actions/upload-artifact@v4.4.3
         with:
           name: jacoco-report
-          path: target/site/jacoco/
+          path: |
+            target/site/jacoco/
+            **/target/site/jacoco/
 
       - name: Publish Code Coverage Results
         if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -95,6 +95,12 @@ on:
           Specifies the release files that should be attached to the GitHub release.  For example a 
           downloadable package that is generated from the repository.  Regardless of this value we 
           will always attach the SBOMs to the release.
+      PUBLISH_JACOCO_REPORT:
+        required: false
+        type: boolean
+        default: false
+        description: | 
+          Specifies that Jacoco Code Coverage reports be published as part of the build.
     secrets:
       MVN_USER_NAME:
         required: false
@@ -299,6 +305,21 @@ jobs:
           cache-dir: .trivy
           # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
           cache: false
+
+      - name: Upload JaCoCo Report
+        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+
+      - name: Publish Code Coverage Results
+        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
+        uses: dorny/test-reporter@master
+        with:
+          name: Code Coverage Report
+          path: target/site/jacoco/index.html
+          reporter: jacoco
 
       - name: Detect Maven version
         id: project

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -315,14 +315,6 @@ jobs:
             target/site/jacoco/
             **/target/site/jacoco/
 
-      - name: Publish Code Coverage Results
-        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
-        uses: dorny/test-reporter@master
-        with:
-          name: Code Coverage Report
-          path: target/site/jacoco/index.html
-          reporter: jacoco
-
       - name: Detect Maven version
         id: project
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
For testing purposes initially, so only applying to maven.yml at present