### PR TITLE
fix: [CORE-754] Adding Jacoco Code Coverage Reports as artifacts for the parallel build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -289,7 +289,7 @@ jobs:
           path: trivy-report.json
           retention-days: 30
 
-      - name: Fail build on High/Criticial Vulnerabilities
+      - name: Fail build on High/Critical Vulnerabilities
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: aquasecurity/trivy-action@master
         env:

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -209,7 +209,17 @@ jobs:
           else
             mvn ${{ inputs.MAVEN_BUILD_GOALS }} --batch-mode -U -P${{ inputs.DOCKER_PROFILE }} -pl :${{ matrix.module }} -Dgpg.skip ${{ inputs.MAVEN_ARGS }}
           fi
-    
+
+      - name: JaCoCo Report - ${{ matrix.module }})
+        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: jacoco-report-${{ matrix.module }}
+          path: |
+            target/site/jacoco/
+            **/target/site/jacoco/
+  
+
   scan-and-publish:
     needs: build
     runs-on: ubuntu-latest
@@ -332,16 +342,6 @@ jobs:
           cache-dir: .trivy
           # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
           cache: false
-
-      - name: Upload JaCoCo Report
-        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: jacoco-report
-          path: |
-            target/site/jacoco/
-            **/target/site/jacoco/
-
       - name: Detect Maven version
         id: project
         run: |

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -211,7 +211,7 @@ jobs:
           fi
 
       - name: JaCoCo Report - ${{ matrix.module }})
-        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
+        if: ${{ inputs.PUBLISH_JACOCO_REPORT }}
         uses: actions/upload-artifact@v4.4.3
         with:
           name: jacoco-report-${{ matrix.module }}

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -89,6 +89,12 @@ on:
           Specifies the release files that should be attached to the GitHub release.  For example a 
           downloadable package that is generated from the repository.  Regardless of this value we 
           will always attach the SBOMs to the release.
+      PUBLISH_JACOCO_REPORT:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Specifies that Jacoco Code Coverage reports be published as part of the build.
     secrets:
       MVN_USER_NAME:
         required: false
@@ -311,7 +317,7 @@ jobs:
           path: trivy-report.json
           retention-days: 30
 
-      - name: Fail build on High/Criticial Vulnerabilities
+      - name: Fail build on High/Critical Vulnerabilities
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_SKIP_DB_UPDATE: true
@@ -326,6 +332,15 @@ jobs:
           cache-dir: .trivy
           # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
           cache: false
+
+      - name: Upload JaCoCo Report
+        if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: jacoco-report
+          path: |
+            target/site/jacoco/
+            **/target/site/jacoco/
 
       - name: Detect Maven version
         id: project


### PR DESCRIPTION
As a follow-up to https://github.com/telicent-oss/shared-workflows/pull/104
And also correcting typo.