### PR TITLE
Enable Remote VEX statements (TELDEVOPS-589)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -115,6 +115,15 @@ on:
         default: false
         description: | 
           Specifies that Jacoco Code Coverage reports be published as part of the build.
+      REMOTE_VEX:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Specifies a new line separated list of repository references from which remote VEX statements should be
+          obtained and supplied to security scanners to filter out vulnerabilities.
+
+          Generally only needed if your repository relies on other libraries that have applicable VEX statements.
     secrets:
       MVN_USER_NAME:
         required: false
@@ -280,6 +289,8 @@ jobs:
           scan-type: fs
           scan-name: maven
           scan-ref: .
+          remote-vex: |
+            ${{ inputs.REMOTE_VEX }}
 
       - name: Upload JaCoCo Report
         if: ${{ matrix.os == 'ubuntu-latest'  && inputs.PUBLISH_JACOCO_REPORT }}

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -107,6 +107,15 @@ on:
         default: false
         description: |
           Specifies that Jacoco Code Coverage reports be published as part of the build.
+      REMOTE_VEX:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Specifies a new line separated list of repository references from which remote VEX statements should be
+          obtained and supplied to security scanners to filter out vulnerabilities.
+
+          Generally only needed if your repository relies on other libraries that have applicable VEX statements.
     secrets:
       MVN_USER_NAME:
         required: false
@@ -340,6 +349,8 @@ jobs:
           scan-type: fs
           scan-name: maven
           scan-ref: .
+          remote-vex: |
+            ${{ inputs.REMOTE_VEX }}
 
       - name: Detect Maven version
         id: project

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -24,6 +24,15 @@ on:
         description: |
           Scan a Docker image tar stored as an artifact (name must be ${SCAN_NAME}.tar), rather
           than an image stored in a remote repository
+      REMOTE_VEX:
+        required: false
+        type: string
+        description: |
+          Supplies references to one/more repositories from which additional VEX statements should be obtained and used
+          to filter out vulnerabilities that have been assessed as to not apply to our software products.
+
+          Note that telicent-oss/telicent-base-images is always included by default so this is only needed if the image
+          being built relies on other images/libraries for which VEX statements are required.
       SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE:
         required: false
         default: false
@@ -78,6 +87,10 @@ jobs:
           scan-name: docker-${{ inputs.SCAN_NAME }}
           scan-ref: ${{ inputs.IMAGE_REF }}
           uses-java: ${{ inputs.USES_JAVA }}
+          allow-unfixed: ${{ inputs.SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE }}
+          remote-vex: |
+            telicent-oss/telicent-base-images
+            ${{ inputs.REMOTE_VEX }}
 
       - name: Generate SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
@@ -105,20 +118,3 @@ jobs:
         with:
           files: |
             ${{ steps.trivy-scan.outputs.scan-results-file }}
-
-      - name: Fail Build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-        with:
-          scan-type: "image"
-          image-ref: ${{ inputs.IMAGE_REF }}
-          format: table
-          severity: HIGH,CRITICAL
-          ignore-unfixed: ${{ inputs.SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE }}
-          exit-code: 1
-          cache-dir: .trivy
-          # Counter-intuitive BUT trivy-action has its own cache which duplicates our own but in a less flexible way
-          cache: false
-          trivyignores: ${{ inputs.PATH_TO_TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE }}


### PR DESCRIPTION
Updates usage of our `telicent-oss/trivy-action` to use the new `remote-vex` input feature.  In particular for Docker builds this ensures that we pick up VEX statements from the base images repository by default so a vulnerability assessed and determined to not affect us in the base images isn't flagged in every downstream repository