### PR TITLE
Update to latest actions/setup-java

### DIFF
--- a/.github/workflows/docker-push-to-registries.yml
+++ b/.github/workflows/docker-push-to-registries.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Install Java and Maven
         if: ${{ inputs.USES_MAVEN }}
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Install Java 17
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/maven-cache-dependencies.yml
+++ b/.github/workflows/maven-cache-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}

--- a/.github/workflows/maven-github-release.yml
+++ b/.github/workflows/maven-github-release.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -225,7 +225,7 @@ jobs:
           restore-only: ${{ github.ref_name != inputs.MAIN_BRANCH }}
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -176,7 +176,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}
@@ -228,7 +228,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       
       - name: Install Java and Maven
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}
@@ -307,7 +307,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: ${{ inputs.JAVA_VERSION }}
           distribution: ${{ inputs.JDK }}


### PR DESCRIPTION
Use the latest `actions/setup-java` to avoid issues with deprecated Actions Cache APIs