### PR TITLE
fix: Do not propagate TRIVY_VEX env variable

### DIFF
--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -95,6 +95,11 @@ jobs:
       - name: Generate SBOM for image (IF has tags for release)
         if: startsWith(github.ref, 'refs/tags/')
         uses: aquasecurity/trivy-action@master
+        env:
+          # NB - Our prior Trivy step MAY generate a TRIVY_VEX file and add it to GITHUB_ENV but it also removes that
+          #      file thus subsequent Trivy steps, like this one, can fail due to the missing file.  We can however
+          #      explicitly override it to an empty string to avoid that.
+          TRIVY_VEX: ""
         with:
           scan-type: "image"
           format: "cyclonedx"


### PR DESCRIPTION
We are seeing trivy failures in Releases
https://github.com/telicent-oss/smart-cache-graph/actions/runs/15023460880/job/42219235178

This mimics
https://github.com/telicent-oss/telicent-base-images/pull/177