### PR TITLE
chore(python): support rust based python libraries

### DIFF
--- a/.github/workflows/python-create-release-pr.yml
+++ b/.github/workflows/python-create-release-pr.yml
@@ -19,6 +19,10 @@ on:
         default: pyproject.toml
         required: false
         type: string
+      RELEASE_TYPE:
+        default: python
+        required: false
+        type: string
 
 jobs:
   create-release-pr:
@@ -26,7 +30,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v3
         with:
-          release-type: python
+          release-type: ${{ inputs.RELEASE_TYPE }}
           package-name: release-please-action
           prerelease: ${{ inputs.PRE_RELEASE }}
           default-branch: ${{ inputs.DEFAULT_BRANCH }}

--- a/.github/workflows/python-create-release-pr.yml
+++ b/.github/workflows/python-create-release-pr.yml
@@ -15,6 +15,10 @@ on:
         default: true
         required: false
         type: boolean
+      VERSION_FILE:
+        default: pyproject.toml
+        required: false
+        type: string
 
 jobs:
   create-release-pr:
@@ -27,8 +31,8 @@ jobs:
           prerelease: ${{ inputs.PRE_RELEASE }}
           default-branch: ${{ inputs.DEFAULT_BRANCH }}
           extra-files: |
-            "pyproject.toml"
-          version-file: pyproject.toml
+            ${{ inputs.VERSION_FILE }}
+          version-file: ${{ inputs.VERSION_FILE }}
           changelog-types: '[
           {"type":"feat","section":"Features","hidden":false},
           {"type":"fix","section":"Bug Fixes","hidden":false},

--- a/.github/workflows/python-gh-release.yml
+++ b/.github/workflows/python-gh-release.yml
@@ -11,6 +11,10 @@ on:
         default: pyproject.toml
         required: false
         type: string
+      RELEASE_TYPE:
+        default: python
+        required: false
+        type: string
 
 jobs:
   do-release:
@@ -18,3 +22,4 @@ jobs:
     with:
       SKIP_GITHUB_RELEASE: false
       VERSION_FILE: ${{ inputs.VERSION_FILE }}
+      RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}

--- a/.github/workflows/python-gh-release.yml
+++ b/.github/workflows/python-gh-release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   do-release:
-    uses: telicent-oss/shared-workflows/.github/workflows/python-create-release-pr.yml@tpt-396-rust-builds
+    uses: telicent-oss/shared-workflows/.github/workflows/python-create-release-pr.yml@main
     with:
       SKIP_GITHUB_RELEASE: false
       VERSION_FILE: ${{ inputs.VERSION_FILE }}

--- a/.github/workflows/python-gh-release.yml
+++ b/.github/workflows/python-gh-release.yml
@@ -7,9 +7,14 @@ on:
         required: false
         type: string
         description: The version being released
+      VERSION_FILE:
+        default: pyproject.toml
+        required: false
+        type: string
 
 jobs:
   do-release:
-    uses: telicent-oss/shared-workflows/.github/workflows/python-create-release-pr.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/python-create-release-pr.yml@tpt-396-rust-builds
     with:
       SKIP_GITHUB_RELEASE: false
+      VERSION_FILE: ${{ inputs.VERSION_FILE }}


### PR DESCRIPTION
Change to allow projects to override the python/pyproject.toml options of release please with rust/Cargo.toml for our Rust based Python libraries.

An alternative approach would have been to make whole new workflows for Rust, but this option seemed like the easier to maintain (fewer .yml files).

Example usage: https://github.com/Telicent-io/rusty-pdp/blob/main/.github/workflows/create-release-pr.yml