### PR TITLE
fix(create-yarnrc-file): add custom fontawesome kit registry

### DIFF
--- a/.github/actions/yarn-prepare/create-yarnrc-file.sh
+++ b/.github/actions/yarn-prepare/create-yarnrc-file.sh
@@ -2,5 +2,6 @@
 
 npm config set "@telicent-io:registry" "https://npm.pkg.github.com/"
 npm config set "//npm.pkg.github.com/:_authToken" $PACKAGE_PAT
+npm config set "@awesome.me:registry" https://npm.fontawesome.com/
 npm config set "@fortawesome:registry" https://npm.fontawesome.com/
 npm config set  "//npm.fontawesome.com/:_authToken" $FONT_AWESOME_KEY


### PR DESCRIPTION
## Context
We have created some custom icons in font-awesome, to allow apps to use them we must add the 'kit' registry to the `.yarnrc` file.

Uses the the same key as fa pro.

My local `.npmrc` file

```bash
@awesome.me:registry=https://npm.fontawesome.com/
@fortawesome:registry=https://npm.fontawesome.com/
//npm.fontawesome.com/:_authToken=XXXXX-XXXXXX-XXXXX
```