### PR TITLE
Add action for Helm metadata-updater script

### DIFF
--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -46,6 +46,8 @@ runs:
       id: metadata-updater
       shell: bash
       run: |
+        echo $PWD
+        ls -lart
         INCLUDE=${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
         EXCLUDE=${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
         python "${{ github.action_path }}/metadata-updater.py" --ci $INCLUDE $EXCLUDE

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -35,7 +35,8 @@ runs:
     - name: Checkout
       uses: actions/checkout@v6
       with:
-        filter: /charts
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: false
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -7,9 +7,11 @@ description: |
 author: Telicent
 
 inputs:
-  sparse-checkout:
+  charts-path:
     required: false
-    description: A list of paths to include in the sparse checkout.
+    description: |
+      The path to the Helm charts to run the metadata updater against.
+      The path should be relative to the root of the repository.
     default: /charts
   include-charts:
     required: false
@@ -31,7 +33,7 @@ runs:
     - name: Checkout
       uses: actions/checkout@v6
       with:
-        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout: ${{ inputs.charts-path }}
         sparse-checkout-cone-mode: false
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -41,11 +43,9 @@ runs:
       id: metadata-updater
       shell: bash
       run: |
-        echo $PWD
-        ls charts/*
         INCLUDE=${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
         EXCLUDE=${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
-        python "${{ github.action_path }}/metadata-updater.py" --ci $INCLUDE $EXCLUDE
+        python "${{ github.action_path }}/metadata-updater.py" --ci --path ${{ inputs.charts-path }} $INCLUDE $EXCLUDE
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -12,7 +12,7 @@ inputs:
     description: |
       The path to the Helm charts to run the metadata updater against.
       The path should be relative to the root of the repository.
-    default: /charts
+    default: charts
   include-charts:
     required: false
     description: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -46,7 +46,9 @@ runs:
       id: metadata-updater
       shell: python
       run: |
-        python --ci --include "${{ inputs.include-charts }}" --exclude "${{ inputs.exclude-charts }}" "${{ github.action_path }}/metadata-updater.py"
+        python "${{ github.action_path }}/metadata-updater.py" --ci \
+          ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '' }} \
+          ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '' }}
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -44,11 +44,11 @@ runs:
         node-version: "24"
     - name: Run metadata updater
       id: metadata-updater
-      shell: python
+      shell: bash
       run: |
-        # include = ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
-        # exclude = ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
-        python "${{ github.action_path }}/metadata-updater.py" --ci
+        INCLUDE=${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
+        EXCLUDE=${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
+        python "${{ github.action_path }}/metadata-updater.py" --ci $INCLUDE $EXCLUDE
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -46,9 +46,9 @@ runs:
       id: metadata-updater
       shell: python
       run: |
-        include = ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
-        exclude = ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
-        python "${{ github.action_path }}/metadata-updater.py" --ci include exclude
+        # include = ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
+        # exclude = ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
+        python "${{ github.action_path }}/metadata-updater.py" --ci
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -10,11 +10,7 @@ inputs:
   sparse-checkout:
     required: false
     description: A list of paths to include in the sparse checkout.
-    default: |
-      /charts/**/readme.config
-      /charts/**/README.md
-      /charts/**/values.schema.json
-      /charts/**/values.yaml
+    default: /charts
   include-charts:
     required: false
     description: |
@@ -46,7 +42,6 @@ runs:
       shell: bash
       run: |
         echo $PWD
-        ls .dev -lart
         ls charts/*
         INCLUDE=${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
         EXCLUDE=${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -46,8 +46,8 @@ runs:
       id: metadata-updater
       shell: python
       run: |
-        include = ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '' }}
-        exclude = ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '' }}
+        include = ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
+        exclude = ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
         python "${{ github.action_path }}/metadata-updater.py" --ci include exclude
     - name: Check for uncommitted changes
       shell: bash

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -36,9 +36,7 @@ runs:
         sparse-checkout: ${{ inputs.charts-path }}
         sparse-checkout-cone-mode: false
     - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: "24"
+      uses: actions/setup-node@v6
     - name: Run metadata updater
       id: metadata-updater
       shell: bash

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -46,7 +46,7 @@ runs:
       id: metadata-updater
       shell: python
       run: |
-        python ${{ github.action_path }}/metadata-updater.py --ci --include "${{ inputs.include-charts }}" --exclude "${{ inputs.exclude-charts }}"
+        python --ci --include "${{ inputs.include-charts }}" --exclude "${{ inputs.exclude-charts }}" "${{ github.action_path }}/metadata-updater.py"
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -1,0 +1,61 @@
+name: Metadata Updater
+description: |
+  A GitHub Action that checks if the README file and JSON schema for a Helm
+  chart are up to date with the values.yaml file. If they are not, the action
+  will fail and print a report. This action is intended to be used in a workflow
+  that pushes a Helm chart to a an artifact repository.
+author: Telicent
+
+inputs:
+  sparse-checkout:
+    required: false
+    description: A list of paths to include in the sparse checkout.
+    default: |
+      /.dev/metadata-updater.py
+      /charts/**/readme.config
+      /charts/**/README.md
+      /charts/**/values.schema.json
+      /charts/**/values.yaml
+  include-charts:
+    required: false
+    description: |
+      A space separated list of charts to include in the check.
+      Paths should be relative to the root of the repository.
+      If not provided, all charts will be included.
+  exclude-charts:
+    required: false
+    description: |
+      A space separated list of charts to exclude from the check.
+      Paths should be relative to the root of the repository.
+      If not provided, no charts will be excluded.
+      Ignored if `include-charts` is provided.
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: false
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "24"
+    - name: Run metadata updater
+      id: metadata-updater
+      shell: python
+      run: |
+        python ${{ github.action_path }}/metadata-updater.py --ci --include "${{ inputs.include-charts }}" --exclude "${{ inputs.exclude-charts }}"
+    - name: Check for uncommitted changes
+      shell: bash
+      run: |
+        has_diff=$(git diff || true)
+        if [[ -z "$has_diff" ]]; then
+          echo "✓ All documentation is up to date"
+        else
+          echo "[ERROR]✗ README files and schemas are out of sync with values.yaml"
+          echo "[ERROR]Please run '.dev/metadata-updater.sh' locally and commit the changes"
+          git diff
+          exit 1
+        fi

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -46,9 +46,9 @@ runs:
       id: metadata-updater
       shell: python
       run: |
-        python "${{ github.action_path }}/metadata-updater.py" --ci \
-          ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '' }} \
-          ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '' }}
+        include = ${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '' }}
+        exclude = ${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '' }}
+        python "${{ github.action_path }}/metadata-updater.py" --ci include exclude
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -11,7 +11,6 @@ inputs:
     required: false
     description: A list of paths to include in the sparse checkout.
     default: |
-      /.dev/metadata-updater.py
       /charts/**/readme.config
       /charts/**/README.md
       /charts/**/values.schema.json
@@ -36,8 +35,7 @@ runs:
     - name: Checkout
       uses: actions/checkout@v6
       with:
-        sparse-checkout: ${{ inputs.sparse-checkout }}
-        sparse-checkout-cone-mode: false
+        filter: /charts
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/actions/helm-metadata-updater/action.yaml
+++ b/.github/actions/helm-metadata-updater/action.yaml
@@ -47,7 +47,8 @@ runs:
       shell: bash
       run: |
         echo $PWD
-        ls -lart
+        ls .dev -lart
+        ls charts/*
         INCLUDE=${{ inputs.include-charts != '' && format('"--include {0}"', inputs.include-charts) || '""' }}
         EXCLUDE=${{ inputs.exclude-charts != '' && format('"--exclude {0}"', inputs.exclude-charts) || '""' }}
         python "${{ github.action_path }}/metadata-updater.py" --ci $INCLUDE $EXCLUDE

--- a/.github/actions/helm-metadata-updater/metadata-updater.py
+++ b/.github/actions/helm-metadata-updater/metadata-updater.py
@@ -26,11 +26,11 @@ class ArgsFactory:
             'omitted.'))
     parser.add_argument('--include', '-i', nargs='*', metavar='chart',
         help=('A space separated list of charts to include. Paths should be '
-            'relative from the root of the repository. Takes precedence '
+            'relative to the root of the repository. Takes precedence '
             'over `--exclude`.'), default=[])
     parser.add_argument('--exclude', '-e', nargs='*', metavar='chart',
         help=('A space separated list of charts to exclude. Paths should be '
-            'relative from the root of the repository. Ignored if `--include` '
+            'relative to the root of the repository. Ignored if `--include` '
             'is specified.'), default=[])
 
     @staticmethod
@@ -42,9 +42,9 @@ class ArgsFactory:
         Example
         -------
         >>> ArgsFactory.parse(['--ci', '--exclude', 'charts/test-chart'])
-        Namespace(ci=True, include=[], exclude=['charts/test-chart'])
-        >>> ArgsFactory.parse(['--ci', '--include', 'charts/test-chart'])
-        Namespace(ci=True, include=['charts/test-chart'], exclude=[])
+        Namespace(ci=True, path='./charts', include=[], exclude=['charts/test-chart'])
+        >>> ArgsFactory.parse(['--ci', '--path', './different-path', '--include', 'charts/test-chart'])
+        Namespace(ci=True, path='./different-path', include=['charts/test-chart'], exclude=[])
         >>> ArgsFactory.parse(['--help'])
         Traceback (most recent call last):
         SystemExit: 0
@@ -186,17 +186,17 @@ class ChartProcessor:
 
         @param path: The path to where Helm charts are located.
         @param include: A list of charts to include. Takes precedence `exclude`.
-            Paths should be relative from the root of the repository.
+            Paths should be relative to the root of the repository.
         @param exclude: A list of charts to exclude. Paths should be relative
-            from the root of the repository.
+            to the root of the repository.
 
         Example
         -------
-        >>> test_charts = ChartProcessor.get_charts()
+        >>> test_charts = ChartProcessor.get_charts('./charts')
         '''
 
         charts = {}
-        for path in Path('charts').glob('**/Chart.yaml'):
+        for path in Path(path).glob('**/Chart.yaml'):
             chart_obj = path.parent
             chart = str(chart_obj)
 
@@ -226,7 +226,7 @@ class ChartProcessor:
         Example
         -------
         >>> readme_generator_cmd = '.dev/readme-generator-for-helm'
-        >>> test_charts = ChartProcessor.get_charts()
+        >>> test_charts = ChartProcessor.get_charts('./charts')
         >>> test_chart = next(iter(test_charts))
         >>> ChartProcessor.process_chart('test-fake-chart', 'charts/does-not-exist', readme_generator_cmd)
         Traceback (most recent call last):

--- a/.github/actions/helm-metadata-updater/metadata-updater.py
+++ b/.github/actions/helm-metadata-updater/metadata-updater.py
@@ -21,6 +21,9 @@ class ArgsFactory:
         help='Show this help message and exit.')
     parser.add_argument('--ci', '-c', action='store_true', default=False,
         help='Indicate execution is happening in a CI environment.')
+    parser.add_argument('--path', '-p', default='./charts',
+        help=('The path to the Helm charts to inspect. Assumes ./charts if '
+            'omitted.'))
     parser.add_argument('--include', '-i', nargs='*', metavar='chart',
         help=('A space separated list of charts to include. Paths should be '
             'relative from the root of the repository. Takes precedence '
@@ -177,10 +180,11 @@ class ChartProcessor:
     }
 
     @classmethod
-    def get_charts(cls, include: list[str]=[], exclude: list[str]=[]) -> dict[str, str]:
+    def get_charts(cls, path: str, include: list[str]=[], exclude: list[str]=[]) -> dict[str, str]:
         '''Returns a dictionary of all chart name -> chart path for all charts
         in the charts directory, excluding those in the `exclude` list.
 
+        @param path: The path to where Helm charts are located.
         @param include: A list of charts to include. Takes precedence `exclude`.
             Paths should be relative from the root of the repository.
         @param exclude: A list of charts to exclude. Paths should be relative
@@ -410,7 +414,7 @@ if __name__ == '__main__':
     Console.info('-' * 39)
 
     # Get charts, process them and print a summary of the results.
-    charts = ChartProcessor.get_charts(args.include, args.exclude)
+    charts = ChartProcessor.get_charts(args.path, args.include, args.exclude)
     results = [(chart_name, ChartProcessor.process_chart(chart_name, chart_path, readme_generator_cmd))
             for chart_name, chart_path in sorted(charts.items())]
     ChartProcessor.print_summary(results)

--- a/.github/actions/helm-metadata-updater/metadata-updater.py
+++ b/.github/actions/helm-metadata-updater/metadata-updater.py
@@ -1,0 +1,418 @@
+from collections import OrderedDict
+from pathlib import Path
+import argparse
+import doctest
+import re
+import shlex
+import subprocess
+import sys
+import textwrap
+
+
+class ArgsFactory:
+    '''Factory for an argument parser that defines the arguments required for
+    this script.
+    '''
+
+    formatter = lambda prog: argparse.HelpFormatter(prog, max_help_position=52)
+    parser = argparse.ArgumentParser(add_help=False, formatter_class=formatter,
+        description='Run metadata updates for Helm charts.')
+    parser.add_argument('--help', '-h', action='help',
+        help='Show this help message and exit.')
+    parser.add_argument('--ci', '-c', action='store_true', default=False,
+        help='Indicate execution is happening in a CI environment.')
+    parser.add_argument('--include', '-i', nargs='*', metavar='chart',
+        help=('A space separated list of charts to include. Paths should be '
+            'relative from the root of the repository. Takes precedence '
+            'over `--exclude`.'), default=[])
+    parser.add_argument('--exclude', '-e', nargs='*', metavar='chart',
+        help=('A space separated list of charts to exclude. Paths should be '
+            'relative from the root of the repository. Ignored if `--include` '
+            'is specified.'), default=[])
+
+    @staticmethod
+    def parse(args: list=None) -> argparse.Namespace:
+        '''Parse arguments as defined in the argument parser.
+
+        @param args: A list of arguments to parse. Defaults to `sys.argv`.
+
+        Example
+        -------
+        >>> ArgsFactory.parse(['--ci', '--exclude', 'charts/test-chart'])
+        Namespace(ci=True, include=[], exclude=['charts/test-chart'])
+        >>> ArgsFactory.parse(['--ci', '--include', 'charts/test-chart'])
+        Namespace(ci=True, include=['charts/test-chart'], exclude=[])
+        >>> ArgsFactory.parse(['--help'])
+        Traceback (most recent call last):
+        SystemExit: 0
+        '''
+        return ArgsFactory.parser.parse_args(args)
+
+
+class Colours:
+    '''Define colours for console output.
+    
+    Example
+    -------
+    >>> print(f'{Colours.RED}Red text.{Colours.NC}')
+    \033[91mRed text.\033[0m
+    >>> print(f'{Colours.GREEN}Green text.{Colours.NC}')
+    \033[92mGreen text.\033[0m
+    >>> print(f'{Colours.YELLOW}Yellow text.{Colours.NC}')
+    \033[93mYellow text.\033[0m
+    >>> print(f'{Colours.BLUE}Blue text.{Colours.NC}')
+    \033[94mBlue text.\033[0m
+    '''
+    RED = '\033[91m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    BLUE = '\033[94m'
+    NC = '\033[0m'
+
+
+class Console:
+    '''Define console output methods for different message types.'''
+
+    @classmethod
+    def print(cls, *objects, sep=' ', colour: Colours=Colours.NC, indent: int=0,
+              prefix: str='', end: str='\n') -> None:
+        '''Prints a message to the console.
+
+        @param objects: Objects stringify that will be joined to make a message.
+        @param sep: The separator to join objects with.
+        @param colour: The colour to print the message in.
+        @param indent: The number of spaces to indent each line of the message by.
+        @param prefix: A string prefix to apply to each line of the message.
+        @param end: The string to append to the end of the message.
+
+        Example
+        -------
+        >>> Console.print('Example message.')
+        Example message.
+        >>> Console.print('Example message with indent of 4.', indent=4)
+            Example message with indent of 4.
+        >>> Console.print('Example message with prefix and custom terminator.',
+        ...     prefix='<--', end='-->')
+        <--Example message with prefix and custom terminator.-->
+        '''
+
+        lines = sep.join(map(str, objects)).splitlines(True)
+        prefixed_lines = [prefix + line for line in lines]
+        start_colour = colour if sys.stdout.isatty() else ''
+        end_colour = Colours.NC if sys.stdout.isatty() else ''
+        output = start_colour + ''.join(prefixed_lines) + end_colour
+        print(textwrap.indent(output, ' ' * indent), end=end)
+
+    @classmethod
+    def info(cls, *msgs, **kwargs) -> None:
+        '''Prints a info message to the console. Extends `print`.
+        
+        Example
+        -------
+        >>> Console.info('Example message.')
+        Example message.
+        >>> Console.info('Invalid kwargs.', invalid=True)
+        Traceback (most recent call last):
+        TypeError
+        '''
+        cls.print(*msgs, colour=Colours.BLUE, **kwargs)
+
+    @classmethod
+    def success(cls, *msgs, **kwargs) -> None:
+        '''Prints a success message to the console. Extends `print`.
+        
+        Example
+        -------
+        >>> Console.success('Example message.')
+        Example message.
+        >>> Console.success('Invalid kwargs.', invalid=True)
+        Traceback (most recent call last):
+        TypeError
+        '''
+        cls.print(*msgs, colour=Colours.GREEN, **kwargs)
+
+    @classmethod
+    def warning(cls, *msgs, **kwargs) -> None:
+        '''Prints a warning message to the console. Extends `print`.
+        
+        Example
+        -------
+        >>> Console.warning('Example message.')
+        Example message.
+        >>> Console.warning('Invalid kwargs.', invalid=True)
+        Traceback (most recent call last):
+        TypeError
+        '''
+        cls.print(*msgs, colour=Colours.YELLOW, **kwargs)
+
+    @classmethod
+    def error(cls, *msgs, **kwargs) -> None:
+        '''Prints an error message to the console. Extends `print`.
+        
+        Example
+        -------
+        >>> Console.error('Example message.')
+        Example message.
+        >>> Console.error('Invalid kwargs.', invalid=True)
+        Traceback (most recent call last):
+        TypeError
+        '''
+        cls.print(*msgs, colour=Colours.RED, **kwargs)
+
+
+class ChartProcessor:
+    
+    errors = OrderedDict([
+        ('chart_does_not_exist', {}),
+        ('missing_required_file', {}),
+        ('missing_key', {}),
+        ('non_existing_key', {})
+    ])
+
+    error_headers = {
+        'chart_does_not_exist': 'Charts That Could Not Be Found',
+        'missing_required_file': 'Missing Required Files',
+        'missing_key': 'Missing Keys',
+        'non_existing_key': 'Non-Existing Keys'
+    }
+
+    @classmethod
+    def get_charts(cls, include: list[str]=[], exclude: list[str]=[]) -> dict[str, str]:
+        '''Returns a dictionary of all chart name -> chart path for all charts
+        in the charts directory, excluding those in the `exclude` list.
+
+        @param include: A list of charts to include. Takes precedence `exclude`.
+            Paths should be relative from the root of the repository.
+        @param exclude: A list of charts to exclude. Paths should be relative
+            from the root of the repository.
+
+        Example
+        -------
+        >>> test_charts = ChartProcessor.get_charts()
+        '''
+
+        charts = {}
+        for path in Path('charts').glob('**/Chart.yaml'):
+            chart_obj = path.parent
+            chart = str(chart_obj)
+
+            include_chart = ((include and chart in include)
+                or (not include and chart not in exclude))
+            
+            if include_chart:
+                charts[chart_obj.name] = chart
+
+        missing_charts = {Path(path).name: path for path in set(include) - set(charts.values())}
+        cls.errors['chart_does_not_exist'] = missing_charts
+
+        return charts
+
+    @classmethod
+    def process_chart(cls, chart_name: str, chart_path: str,
+        readme_generator_cmd: str) -> bool:
+        '''Processes a singe chart, returning `True` if the chart metadata is
+        valid, otherwise `False`.
+
+        @param chart_name: The name of the chart to process.
+        @param chart_path: The path to the chart to process.
+        @param readme_generator_cmd: The command to use when running the
+            `readme-generator-for-helm` Node.js package.
+        @param errors: A dictionary to populate with any errors detected.
+
+        Example
+        -------
+        >>> readme_generator_cmd = '.dev/readme-generator-for-helm'
+        >>> test_charts = ChartProcessor.get_charts()
+        >>> test_chart = next(iter(test_charts))
+        >>> ChartProcessor.process_chart('test-fake-chart', 'charts/does-not-exist', readme_generator_cmd)
+        Traceback (most recent call last):
+        FileNotFoundError
+        >>> ChartProcessor.process_chart(test_chart, 'charts/demo-prereqs', readme_generator_cmd)
+        --ignore--
+        True
+        >>> readme_generator_cmd = 'npx @bitnami/readme-generator-for-helm'
+        >>> ChartProcessor.process_chart(test_chart, 'charts/demo-prereqs', readme_generator_cmd)
+        --ignore--
+        True
+        '''
+
+        Console.info('\nProcessing chart:', chart_name)
+
+        # Set paths to files required by the readme generator.
+        chart_path_obj = Path(chart_path)
+        readme_config_file = chart_path_obj / 'readme.config'
+        readme_file = chart_path_obj / 'README.md'
+        values_file = chart_path_obj / 'values.yaml'
+        values_schema_file = chart_path_obj / 'values.schema.json'
+
+        # Test that a README.md file exists. If not, create it.
+        if not readme_file.is_file():
+            with open(readme_file, 'w') as f:
+                Console.warning('README.md file does not exist in chart, so will be created.')
+                f.write(f'# {chart_name}\n\n## Parameters')
+
+        # Run the metadata generator for this chart.
+        cmd = shlex.split(readme_generator_cmd) + [
+            '--config', readme_config_file,
+            '--readme', readme_file,
+            '--values', values_file,
+            '--schema', values_schema_file]
+        
+        try:
+            subprocess.run(cmd, capture_output=True, check=True, text=True)
+            Console.success('  ✓ Completed', chart_name)
+            return True
+
+        except subprocess.CalledProcessError as e:
+            error_text = e.stdout or e.stderr or ''
+            output = '\n'.join(
+                line for line in error_text.splitlines()
+                if line.lower().startswith('error: ')
+            )
+            return_code = e.returncode
+            Console.error('  ✗ Failed to process', chart_name, f'(exit code: {return_code})')
+            Console.print(output, indent=4, prefix='| ')
+
+            # Parse errors from the output.
+            error_patterns = [
+                (r'.*missing metadata for key.*', 'missing_key', True),
+                (r'.*metadata provided for non existing key.*', 'non_existing_key', True),
+                (r'.*no such file or directory.*values\.yaml.*', 'missing_required_file', False),
+                (r'.*no such file or directory.*readme\.config.*', 'missing_required_file', False)]
+            has_metadata_errors = False
+            for pattern, error_key, is_metadata in error_patterns:
+                errors = re.findall(pattern, output, re.IGNORECASE | re.MULTILINE)
+                if errors:
+                    cls.errors[error_key][chart_name] = errors
+                    has_metadata_errors = has_metadata_errors or is_metadata
+
+            if has_metadata_errors:
+                Console.warning('  ⚠', 'Metadata misconfiguration detected')
+
+            return False
+
+    @classmethod
+    def print_summary(cls, results: list[tuple[str, str]]) -> None:
+        '''Prints a summary of the metadata update process, including the number of
+        charts processed successfully and unsuccessfully. Also lists the key errors
+        detected for failed charts.
+
+        Example
+        -------
+        >>> ChartProcessor.print_summary([])
+        --ignore--
+        All charts processed successfully!
+        '''
+
+        Console.info('\n\nProcessing Summary')
+        Console.info('-' * 18)
+
+        successful_charts = [chart_name for chart_name, result in results if result]
+        failed_charts = [chart_name for chart_name, result in results if not result]
+
+        # Output any charts that were successfully processed.
+        if successful_charts:
+            Console.success(f'\n{len(successful_charts)} chart(s) processed successfully -')
+            for chart in successful_charts:
+                Console.success('  ✓', end=' ')
+                Console.print(chart)
+
+        # Output any charts that failed to process.
+        if failed_charts:
+            Console.error(f'\n{len(failed_charts)} chart(s) failed to process -')
+            for chart in failed_charts:
+                Console.error('  ✗', end=' ')
+                Console.print(chart)
+
+            if cls.errors['missing_key'] or cls.errors['non_existing_key']:
+                warning_msg = ('Metadata misconfiguration detected.\n',
+                '-- Add @key annotations to all configuration values in values.yaml.\n',
+                '-- Ensure @section and @descStart/@descEnd are properly formatted.\n',
+                '-- Check that readme.config includes all required sections.\n',
+                '-- Verify values.yaml syntax is valid YAML.')
+                Console.warning('\n⚠', *warning_msg)
+        else:
+            Console.success('\nAll charts processed successfully!')
+        
+        # List chart errors by type.
+        for error_type, charts in ((k, v) for k, v in cls.errors.items() if v):
+            Console.error(f'\n{cls.error_headers[error_type]}')
+            for chart, errors in sorted(charts.items()):
+                Console.error('  ●', end=' ')
+                Console.info(chart, ':', sep='', end=' ')
+                if error_type == 'chart_does_not_exist':
+                    Console.print(errors)
+                else:
+                    errors = [cls._extract_error_message(error) for error in errors]
+                    Console.print(', '.join(errors))
+
+    @staticmethod
+    def _extract_error_message(error: str) -> str:
+        '''Extract the clean error message from a full error string.
+
+        First takes the substring after the last `/` character, then takes the
+        substring after the last `:` character, stripping whitespace ans quotes.
+        
+        @param error: The full error string (e.g. '/file/path: ERROR: message').
+
+        @return str: The clean error message.
+        '''
+        after_path = error[error.rfind('/') + 1:].strip(" '")
+        return after_path[after_path.rfind(':') + 1:].strip()
+
+
+class TestModule:
+    '''Run doctest for this module.'''
+
+    ELLIPSIS_MARKER = '--ignore--'
+    DEFAULT_FLAGS = doctest.IGNORE_EXCEPTION_DETAIL | doctest.ELLIPSIS
+
+    @classmethod
+    def run(cls, module: str=__name__, option_flags:int=None) -> int:
+        '''Execute all module doctest examples and return the exit code.
+        
+        @param module: The name of the module to test. Defaults to `__name__`.
+        @param option_flags: The doctest option flags to use. Defaults to the
+            class `DEFAULT_FLAGS`.
+        '''
+
+        doctest.ELLIPSIS_MARKER = cls.ELLIPSIS_MARKER
+        option_flags = option_flags if option_flags is not None else cls.DEFAULT_FLAGS
+        result = doctest.testmod(name=module, optionflags=option_flags)
+
+        if result.failed:
+            print(f'[ERROR] {result.attempted} doctest(s) run, {result.failed} failed.')
+            return 1
+
+        print(f'[SUCCESS] {result.attempted} doctest(s) run, all passed.')
+        return 0
+
+
+# Preserve the old helper name for compatibility.
+test_module = TestModule.run
+
+
+if __name__ == '__main__':
+    
+    # Test this script if `-t` in sys.argv or '--test' in sys.argv.
+    if '-t' in sys.argv or '--test' in sys.argv:
+        sys.exit(TestModule.run())
+
+    # Parse command line arguments.
+    args = ArgsFactory.parse()
+
+    # Test to see if the script is being run in CI mode, which will allow the
+    # readme generator command to be set accordingly.
+    readme_generator_cmd = ('npx @bitnami/readme-generator-for-helm'
+        if args.ci else '.dev/readme-generator-for-helm')
+
+    Console.info('\nStarting metadata update for all charts')
+    Console.info('-' * 39)
+
+    # Get charts, process them and print a summary of the results.
+    charts = ChartProcessor.get_charts(args.include, args.exclude)
+    results = [(chart_name, ChartProcessor.process_chart(chart_name, chart_path, readme_generator_cmd))
+            for chart_name, chart_path in sorted(charts.items())]
+    ChartProcessor.print_summary(results)
+
+    sys.exit(0 if all([result for _, result in results]) else 1)

--- a/.github/actions/helm-metadata-updater/test_metadata_updater.py
+++ b/.github/actions/helm-metadata-updater/test_metadata_updater.py
@@ -1,0 +1,335 @@
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Load the script file using a Python-safe module name.
+script_path = os.path.join(os.path.dirname(__file__), 'metadata-updater.py')
+spec = importlib.util.spec_from_file_location('metadata_updater', script_path)
+metadata_updater = importlib.util.module_from_spec(spec)
+sys.modules['metadata_updater'] = metadata_updater
+spec.loader.exec_module(metadata_updater)
+
+from metadata_updater import (
+    ArgsFactory, Colours, Console, ChartProcessor
+)
+
+
+class TestArgsFactory(unittest.TestCase):
+    def test_parse_default(self):
+        args = ArgsFactory.parse(['--ci'])
+        self.assertTrue(args.ci)
+        self.assertEqual(args.include, [])
+        self.assertEqual(args.exclude, [])
+
+    def test_parse_include_exclude(self):
+        args = ArgsFactory.parse(['--include', 'chart1', 'chart2', '--exclude', 'chart3'])
+        self.assertFalse(args.ci)
+        self.assertEqual(args.include, ['chart1', 'chart2'])
+        self.assertEqual(args.exclude, ['chart3'])
+
+    def test_parse_help_exits(self):
+        with self.assertRaises(SystemExit):
+            with patch('sys.stdout', new_callable=io.StringIO):
+                ArgsFactory.parse(['--help'])
+
+
+class TestColours(unittest.TestCase):
+    def test_colours_defined(self):
+        self.assertEqual(Colours.RED, '\033[91m')
+        self.assertEqual(Colours.GREEN, '\033[92m')
+        self.assertEqual(Colours.YELLOW, '\033[93m')
+        self.assertEqual(Colours.BLUE, '\033[94m')
+        self.assertEqual(Colours.NC, '\033[0m')
+
+
+class TestConsole(unittest.TestCase):
+    @patch('metadata_updater.sys.stdout.isatty', return_value=True)
+    @patch('builtins.print')
+    def test_print(self, mock_print, mock_isatty):
+        # Test with multiple args, and every kwarg excel for `colour`.
+        # The named functions that follow will test the `colour` kwarg.
+        Console.print('test message', 'with kwargs\non multiple lines',
+                      sep='//', indent=4, prefix='>> ', end=' <<')
+        mock_print.assert_called_once()
+        args, kwargs = mock_print.call_args
+        self.assertEqual((f'    {Colours.NC}>> test message//with kwargs\n'
+                          f'    >> on multiple lines{Colours.NC}'), args[0])
+        self.assertEqual(' <<', kwargs['end'])
+
+    @patch('metadata_updater.sys.stdout.isatty', return_value=False)
+    @patch('builtins.print')
+    def test_print_with_no_colour(self, mock_print, mock_isatty):
+        Console.print('test message', 'with kwargs\non multiple lines',
+                      sep='//', indent=4, prefix='>> ', end=' <<')
+        mock_print.assert_called_once()
+        args, kwargs = mock_print.call_args
+        self.assertEqual(('    >> test message//with kwargs\n'
+                          '    >> on multiple lines'), args[0])
+        self.assertEqual(' <<', kwargs['end'])
+
+    @patch('metadata_updater.sys.stdout.isatty', return_value=True)
+    @patch('builtins.print')
+    def test_info(self, mock_print, mock_isatty):
+        Console.info('info message')
+        args, _ = mock_print.call_args
+        self.assertTrue(args[0].startswith(Colours.BLUE))
+        self.assertTrue(args[0].endswith(Colours.NC))
+
+    @patch('metadata_updater.sys.stdout.isatty', return_value=True)
+    @patch('builtins.print')
+    def test_success(self, mock_print, mock_isatty):
+        Console.success('success message')
+        args, _ = mock_print.call_args
+        self.assertTrue(args[0].startswith(Colours.GREEN))
+        self.assertTrue(args[0].endswith(Colours.NC))
+
+    @patch('metadata_updater.sys.stdout.isatty', return_value=True)
+    @patch('builtins.print')
+    def test_warning(self, mock_print, mock_isatty):
+        Console.warning('warning message')
+        args, _ = mock_print.call_args
+        self.assertTrue(args[0].startswith(Colours.YELLOW))
+        self.assertTrue(args[0].endswith(Colours.NC))
+
+    @patch('metadata_updater.sys.stdout.isatty', return_value=True)
+    @patch('builtins.print')
+    def test_error(self, mock_print, mock_isatty):
+        Console.error('error message')
+        args, _ = mock_print.call_args
+        self.assertTrue(args[0].startswith(Colours.RED))
+        self.assertTrue(args[0].endswith(Colours.NC))
+
+
+class TestGetCharts(unittest.TestCase):
+
+    @patch('pathlib.Path.glob')
+    def test_get_charts_basic(self, mock_glob):
+        mock_glob.return_value = [
+            Path('charts/test-chart/Chart.yaml')
+        ]
+        charts = ChartProcessor.get_charts('charts', [], [])
+        self.assertIn('test-chart', charts)
+        self.assertEqual(charts['test-chart'], 'charts/test-chart')
+        self.assertEqual(ChartProcessor.errors['chart_does_not_exist'], {})
+
+    @patch('pathlib.Path.glob')
+    def test_get_charts_exclude(self, mock_glob):
+        mock_glob.return_value = [
+            Path('charts/included1/Chart.yaml'),
+            Path('charts/included2/Chart.yaml'),
+            Path('charts/excluded/Chart.yaml')
+        ]
+        charts = ChartProcessor.get_charts('charts', [], ['charts/excluded'])
+        self.assertIn('included1', charts)
+        self.assertIn('included2', charts)
+        self.assertNotIn('excluded', charts)
+
+    @patch('pathlib.Path.glob')
+    def test_get_charts_include(self, mock_glob):
+        mock_glob.return_value = [
+            Path('charts/included/Chart.yaml')
+        ]
+        charts = ChartProcessor.get_charts('charts', ['charts/included'], [])
+        self.assertIn('included', charts)
+        self.assertEqual(ChartProcessor.errors['chart_does_not_exist'], {})
+
+    @patch('pathlib.Path.glob')
+    def test_get_charts_include_missing(self, mock_glob):
+        mock_glob.return_value = []
+        charts = ChartProcessor.get_charts('charts', ['charts/missing'], [])
+        self.assertEqual(charts, {})
+        self.assertEqual(ChartProcessor.errors['chart_does_not_exist'], {'missing': 'charts/missing'})
+
+
+class TestProcessChart(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.chart_dir = os.path.join(self.temp_dir, 'test-chart')
+        os.makedirs(self.chart_dir)
+
+        # Create required files
+        with open(os.path.join(self.chart_dir, 'readme.config'), 'w') as f:
+            f.write('config')
+        with open(os.path.join(self.chart_dir, 'README.md'), 'w') as f:
+            f.write(f'# test-chart\n\n## Parameters')
+        with open(os.path.join(self.chart_dir, 'values.schema.json'), 'w') as f:
+            f.write('{}')
+        with open(os.path.join(self.chart_dir, 'values.yaml'), 'w') as f:
+            f.write('key: value')
+        # Clear errors
+        ChartProcessor.errors = {
+            'chart_does_not_exist': {},
+            'missing_required_file': {},
+            'missing_key': {},
+            'non_existing_key': {}
+        }
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir)
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('metadata_updater.Console')
+    def test_process_chart_success(self, mock_console, mock_exists, mock_run):
+        mock_process = MagicMock()
+        mock_run.return_value = mock_process
+        mock_exists.return_value = True
+
+        result = ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertTrue(result)
+        self.assertEqual(ChartProcessor.errors['missing_key'], {})
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('builtins.print')
+    @patch('metadata_updater.sys.stdout.isatty', return_value=False)
+    def test_process_chart_success_outputs_expected_text(self, mock_isatty, mock_print, mock_exists, mock_run):
+        mock_process = MagicMock()
+        mock_run.return_value = mock_process
+        mock_exists.return_value = True
+
+        ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertEqual(mock_print.call_count, 2)
+        self.assertEqual(mock_print.call_args_list[0][0][0], '\nProcessing chart: test-chart')
+        self.assertEqual(mock_print.call_args_list[1][0][0], '  ✓ Completed test-chart')
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('metadata_updater.Console')
+    def test_process_chart_failure_missing_key(self, mock_console, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(1, 'cmd', output='ERROR: Missing metadata for key')
+        mock_exists.return_value = True
+
+        result = ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertFalse(result)
+        self.assertIn('test-chart', ChartProcessor.errors['missing_key'])
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('builtins.print')
+    @patch('metadata_updater.sys.stdout.isatty', return_value=False)
+    def test_process_chart_failure_missing_key_outputs_expected_text(self, mock_isatty, mock_print, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(1, 'cmd', output='ERROR: Missing metadata for key')
+        mock_exists.return_value = True
+
+        ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertEqual(mock_print.call_count, 4)
+        self.assertEqual(mock_print.call_args_list[0][0][0], '\nProcessing chart: test-chart')
+        self.assertEqual(mock_print.call_args_list[1][0][0], '  ✗ Failed to process test-chart (exit code: 1)')
+        self.assertEqual(mock_print.call_args_list[2][0][0], '    | ERROR: Missing metadata for key')
+        self.assertEqual(mock_print.call_args_list[3][0][0], '  ⚠ Metadata misconfiguration detected')
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('metadata_updater.Console')
+    def test_process_chart_failure_non_existing_key(self, mock_console, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(1, 'cmd', output='ERROR: Metadata provided for non existing key')
+        mock_exists.return_value = True
+
+        result = ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertFalse(result)
+        self.assertIn('test-chart', ChartProcessor.errors['non_existing_key'])
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('builtins.print')
+    @patch('metadata_updater.sys.stdout.isatty', return_value=False)
+    def test_process_chart_failure_non_existing_key_outputs_expected_text(self, mock_isatty, mock_print, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(1, 'cmd', output='ERROR: Metadata provided for non existing key')
+        mock_exists.return_value = True
+
+        ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertEqual(mock_print.call_count, 4)
+        self.assertEqual(mock_print.call_args_list[0][0][0], '\nProcessing chart: test-chart')
+        self.assertEqual(mock_print.call_args_list[1][0][0], '  ✗ Failed to process test-chart (exit code: 1)')
+        self.assertEqual(mock_print.call_args_list[2][0][0], '    | ERROR: Metadata provided for non existing key')
+        self.assertEqual(mock_print.call_args_list[3][0][0], '  ⚠ Metadata misconfiguration detected')
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('metadata_updater.Console')
+    def test_process_chart_missing_values_file(self, mock_console, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(2, 'cmd', output='ERROR: no such file or directory: values.yaml')
+        mock_exists.side_effect = lambda path: 'values.yaml' not in path
+
+        result = ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertFalse(result)
+        self.assertIn('test-chart', ChartProcessor.errors['missing_required_file'])
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('builtins.print')
+    @patch('metadata_updater.sys.stdout.isatty', return_value=False)
+    def test_process_chart_missing_values_file_outputs_expected_text(self, mock_isatty, mock_print, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(2, 'cmd', output='ERROR: no such file or directory: values.yaml')
+        mock_exists.side_effect = lambda path: 'values.yaml' not in path
+
+        ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertEqual(mock_print.call_count, 3)
+        self.assertEqual(mock_print.call_args_list[0][0][0], '\nProcessing chart: test-chart')
+        self.assertEqual(mock_print.call_args_list[1][0][0], '  ✗ Failed to process test-chart (exit code: 2)')
+        self.assertEqual(mock_print.call_args_list[2][0][0], '    | ERROR: no such file or directory: values.yaml')
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('metadata_updater.Console')
+    def test_process_chart_missing_readme_config_file(self, mock_console, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(2, 'cmd', output='ERROR: no such file or directory: readme.config')
+        mock_exists.side_effect = lambda path: 'readme.config' not in path
+
+        result = ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertFalse(result)
+        self.assertIn('test-chart', ChartProcessor.errors['missing_required_file'])
+
+    @patch('subprocess.run')
+    @patch('os.path.exists')
+    @patch('builtins.print')
+    @patch('metadata_updater.sys.stdout.isatty', return_value=False)
+    def test_process_chart_missing_readme_config_file_outputs_expected_text(self, mock_isatty, mock_print, mock_exists, mock_run):
+        mock_run.side_effect = __import__('subprocess').CalledProcessError(2, 'cmd', output='ERROR: no such file or directory: readme.config')
+        mock_exists.side_effect = lambda path: 'readme.config' not in path
+
+        ChartProcessor.process_chart('test-chart', self.chart_dir, 'echo test')
+        self.assertEqual(mock_print.call_count, 3)
+        self.assertEqual(mock_print.call_args_list[0][0][0], '\nProcessing chart: test-chart')
+        self.assertEqual(mock_print.call_args_list[1][0][0], '  ✗ Failed to process test-chart (exit code: 2)')
+        self.assertEqual(mock_print.call_args_list[2][0][0], '    | ERROR: no such file or directory: readme.config')
+
+
+class TestPrintSummary(unittest.TestCase):
+    @patch('metadata_updater.Console')
+    def test_print_summary_success(self, mock_console):
+        results = [('test-chart1', True), ('test-chart2', True)]
+        ChartProcessor.errors = {
+            'chart_does_not_exist': {},
+            'missing_required_file': {},
+            'missing_key': {},
+            'non_existing_key': {}
+        }
+
+        ChartProcessor.print_summary(results)
+        mock_console.success.assert_called()
+
+    @patch('metadata_updater.Console')
+    def test_print_summary_failure(self, mock_console):
+        
+        results = [('test-chart1', True), ('test-chart2', False)]
+        ChartProcessor.errors = {
+            'chart_does_not_exist': {},
+            'missing_required_file': {},
+            'missing_key': {'test-chart2': ['error']},
+            'non_existing_key': {}
+        }
+
+        ChartProcessor.print_summary(results)
+        mock_console.error.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -356,7 +356,7 @@ runs:
     - name: Upload container image tarball artefact
       # Only run if dry run is set to anything other than 'false', indicating that this is a dry run
       id: upload-image-artefact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: inputs.dry-run != 'false'
       with:
         name: ${{ inputs.APP_NAME_PREFIX }}${{ inputs.APP_NAME }}${{ inputs.IMAGE_SUFFIX }}.tar

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -85,7 +85,7 @@ runs:
     - name: Upload container image tarball artefact
       # Only run if dry run is set to anything other than 'false', indicating that this is a dry run
       id: upload-image-artefact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ inputs.dry-run != 'false' }}
       with:
         name: ${{ inputs.app-name-prefix }}${{ inputs.app-name }}.tar

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -58,7 +58,7 @@ runs:
         quay-username: "${{ inputs.quay-username }}"
         quay-token: "${{ inputs.quay-token }}"
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@v5
       with:
         version: "latest"
     - name: Checkout Helm chart

--- a/.github/actions/python-generate-sbom/action.yaml
+++ b/.github/actions/python-generate-sbom/action.yaml
@@ -43,7 +43,7 @@ runs:
       run: |
         python -m cyclonedx_py requirements > ${{ inputs.scan-name }}-cyclonedx.sbom.json
     - name: Store the SBOM
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.scan-name}}
         path: ${{ inputs.scan-name }}-cyclonedx.sbom.json

--- a/.github/actions/trivy-repo-scan/action.yml
+++ b/.github/actions/trivy-repo-scan/action.yml
@@ -68,7 +68,7 @@ runs:
       run: cyclonedx-npm --ignore-npm-errors --output-file ${{ steps.globals.outputs.bom-file-name }}
       shell: bash
     - name: Upload SBOM artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.globals.outputs.bom-artifact-name }}
         path: ${{ steps.globals.outputs.bom-file-name }}

--- a/.github/actions/yarn-prepare/action.yml
+++ b/.github/actions/yarn-prepare/action.yml
@@ -52,13 +52,14 @@ runs:
       with: 
         node-version: ${{ inputs.node-version }}
         cache: 'yarn'
-    - name: Prepare cache
-      id: prepare
-      run: |
-        echo "node-version=$(node -v)" >> $GITHUB_OUTPUT
-        echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      shell: bash
-    # not sure if we need this, after adding cache: 'yarn' to Setup node
+    # Deprecated - caching now handled by the Setup node task.
+    # - name: Prepare cache
+    #   id: prepare
+    #   run: |
+    #     echo "node-version=$(node -v)" >> $GITHUB_OUTPUT
+    #     echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+    #   shell: bash
+    # Deprecated - caching now handled by the Setup node task.
     # - name: Cache node_modules
     #   id: node_modules
     #   uses: actions/cache@v4


### PR DESCRIPTION
Now that we plan to have Helm charts in code repos, it's important to have a single source of truth for the metadata updater.

The script can be pulled from the action and run locally if desired using a bash script. This bash script should be in all code repos where a Helm chart will be present. The script will copy and run the Python metadata-updater script. It's suggested that the python script is added to `.gitignore` to save having multiple copies of it in loads of repos.

```
#!/bin/bash
set -e

# Set the path to this script's directory, which is used to locate the metadata-updater.py script.
SCRIPT_PATH=$(dirname "$(realpath $0)")/metadata-updater.py
GENERATOR_PATH=$(dirname "$(realpath $0)")/readme-generator-for-helm

# Copy a fresh version of the metadata-updater.py script from GitHub.
SCRIPT_URL="https://raw.githubusercontent.com/telicent-oss/shared-workflows/refs/heads/TELDEVOPS-997/.github/actions/helm-metadata-updater/metadata-updater.py"
curl -L -s -o "$SCRIPT_PATH" "$SCRIPT_URL"

# Copy a fresh version of the readme-generator-for-helm binary from GitHub.
if [[ "$@" != *"--ci"* ]]; then
    GENERATOR_URL="https://raw.githubusercontent.com/telicent-oss/shared-workflows/refs/heads/TELDEVOPS-997/.github/actions/helm-metadata-updater/readme-generator-for-helm"
    curl -L -s -o "$GENERATOR_PATH" "$GENERATOR_URL"
    chmod +x $GENERATOR_PATH
fi

# Run the script, passing through any arguments.
python "$SCRIPT_PATH" "$@"
```

