### PR TITLE
Teldevops 997/image and chart signing

### DIFF
--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -320,8 +320,10 @@ runs:
         cache-to: type=gha,mode=max
         context: ${{ inputs.path }}
         file: ${{ inputs.path }}/${{ inputs.dockerfile }}
+        provenance: mode=max
         tags: ${{ steps.meta.outputs.tags }}
         target: ${{ inputs.target }}
+        sbom: true
         secrets: |
           ${{ inputs.package-pat && inputs.package-pat || '' }}
           ${{ inputs.font-awesome-key && inputs.font-awesome-key || '' }}

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -426,3 +426,22 @@ runs:
         image-url: ${{ steps.capture-tags.outputs.image }}
         registry: ${{ inputs.registry == 'quay' && 'Quay.io' || inputs.registry == 'aws' && 'ECR' || '' }}
         status: ${{ steps.build-images.outcome }}
+
+
+    - name: Install CoSign
+      # Only run if dry run is explicitly set to 'false'
+      if: ${{ inputs.dry-run == 'false' }}
+      uses: sigstore/cosign-installer@v3
+    - name: Sign charts on Quay.io
+      # Only run if dry run is explicitly set to 'false'
+      if: ${{ inputs.dry-run == 'false' }}
+      shell: bash
+      run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+      env:
+        DIGEST: ${{ steps.build-images.outputs.digest }}
+        TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -354,12 +354,12 @@ runs:
         outputs: type=docker,dest=/tmp/${{ inputs.app-name-prefix }}${{ inputs.app-name }}${{ inputs.image-suffix }}.tar
 
     - name: Install CoSign
-      # Only run if dry run is explicitly set to 'false'
-      if: inputs.dry-run == 'false'
+      # Only run if dry run is explicitly set to 'false' and the image is being pushed to 'quay'.
+      if: inputs.dry-run == 'false' && inputs.registry == 'quay'
       uses: sigstore/cosign-installer@v3
     - name: Sign charts on Quay.io
-      # Only run if dry run is explicitly set to 'false'
-      if: inputs.dry-run == 'false'
+      # Only run if dry run is explicitly set to 'false' and the image is being pushed to 'quay'.
+      if: inputs.dry-run == 'false' && inputs.registry == 'quay'
       shell: bash
       env:
         DIGEST: ${{ steps.build-images.outputs.digest }}

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -353,6 +353,24 @@ runs:
           ${{ inputs.build-args }}
         outputs: type=docker,dest=/tmp/${{ inputs.app-name-prefix }}${{ inputs.app-name }}${{ inputs.image-suffix }}.tar
 
+    - name: Install CoSign
+      # Only run if dry run is explicitly set to 'false'
+      if: inputs.dry-run == 'false'
+      uses: sigstore/cosign-installer@v3
+    - name: Sign charts on Quay.io
+      # Only run if dry run is explicitly set to 'false'
+      if: inputs.dry-run == 'false'
+      shell: bash
+      env:
+        DIGEST: ${{ steps.build-images.outputs.digest }}
+        TAGS: ${{ steps.meta.outputs.tags }}
+      run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
     - name: Upload container image tarball artefact
       # Only run if dry run is set to anything other than 'false', indicating that this is a dry run
       id: upload-image-artefact
@@ -426,22 +444,3 @@ runs:
         image-url: ${{ steps.capture-tags.outputs.image }}
         registry: ${{ inputs.registry == 'quay' && 'Quay.io' || inputs.registry == 'aws' && 'ECR' || '' }}
         status: ${{ steps.build-images.outcome }}
-
-
-    - name: Install CoSign
-      # Only run if dry run is explicitly set to 'false'
-      if: ${{ inputs.dry-run == 'false' }}
-      uses: sigstore/cosign-installer@v3
-    - name: Sign charts on Quay.io
-      # Only run if dry run is explicitly set to 'false'
-      if: ${{ inputs.dry-run == 'false' }}
-      shell: bash
-      run: |
-          images=""
-          for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
-          done
-          cosign sign --yes ${images}
-      env:
-        DIGEST: ${{ steps.build-images.outputs.digest }}
-        TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -146,12 +146,12 @@ runs:
         AWS_REGISTRY: ${{ inputs.registry == 'aws' && format('oci://{0}/charts' ,steps.login-ecr.outputs.registry) || '' }}
         QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'oci://quay.io/telicent/charts' || '' }}
     - name: Install CoSign
-      # Only run if dry run is explicitly set to 'false'
-      if: inputs.dry-run == 'false'
+      # Only run if dry run is explicitly set to 'false' and the image is being pushed to 'quay'.
+      if: inputs.dry-run == 'false' && inputs.registry == 'quay'
       uses: sigstore/cosign-installer@v3
     - name: Sign charts on Quay.io
-      # Only run if dry run is explicitly set to 'false'
-      if: inputs.dry-run == 'false'
+      # Only run if dry run is explicitly set to 'false' and the image is being pushed to 'quay'.
+      if: inputs.dry-run == 'false' && inputs.registry == 'quay'
       shell: bash
       run: |
         REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -126,10 +126,41 @@ runs:
       if: ${{ inputs.dry-run == 'false' }}
       shell: bash
       run: |
+
+        # Create/truncate `REFS_FILE` to use for cosigning.
+        REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"
+        : > "$REFS_FILE"
+
+        # Push the Helm chart.
         echo "Pushing Helm chart "$PACKAGED_CHART" to ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }}"
-        helm push "$PACKAGED_CHART" ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }}
+        OUTPUT=$(helm push "$PACKAGED_CHART" ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }})
+        echo $OUTPUT
         echo "  ✅ Helm chart pushed successfully"
+
+        # Capture the digest of the image that was pushed to enable signing.
+        pushed=$(echo "$output" | grep "^Pushed:" | awk '{print $2}')
+        digest=$(echo "$output" | grep "^Digest:" | awk '{print $2}')
+        printf "%s@%s\n" "$pushed" "$digest" >> "$refs_file"
       env:
         PACKAGED_CHART: "${{ runner.temp }}/packaged-chart/${{ inputs.app-name-prefix }}${{ inputs.app-name }}-${{ inputs.version }}.tgz"
         AWS_REGISTRY: ${{ inputs.registry == 'aws' && format('oci://{0}/charts' ,steps.login-ecr.outputs.registry) || '' }}
         QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'oci://quay.io/telicent/charts' || '' }}
+    - name: Install CoSign
+      # Only run if dry run is explicitly set to 'false'
+      if: ${{ inputs.dry-run == 'false' }}
+      uses: sigstore/cosign-installer@v3
+    - name: Sign charts on Quay.io
+      # Only run if dry run is explicitly set to 'false'
+      if: ${{ inputs.dry-run == 'false' }}
+      shell: bash
+      run: |
+        REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"
+        if [[ ! -s "$REFS_FILE" ]]; then
+          echo "No pushed chart references found to sign"
+          exit 1
+        fi
+        while IFS= read -r ref; do
+          [[ -n "$ref" ]] || continue
+          echo "signing $ref"
+          cosign sign --yes "$ref"
+        done < "$REFS_FILE"

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -129,23 +129,20 @@ runs:
 
         # Push the Helm chart.
         echo "Pushing Helm chart "$PACKAGED_CHART" to ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }}"
-        OUTPUT=$(helm push "$PACKAGED_CHART" ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }})
+        OUTPUT=$(helm push "$PACKAGED_CHART" ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }} 2>&1)
         echo $OUTPUT
         echo "  ✅ Helm chart pushed successfully"
 
         # Capture the digest of the image that was pushed to enable signing.
-        echo "echo \"$OUTPUT\" | grep \"^Pushed:\" | awk '{print $2}'"
         PUSHED=$(echo "$OUTPUT" | grep "^Pushed:" | awk '{print $2}')
-        echo "echo \"$OUTPUT\" | grep \"^Digest:\" | awk '{print $2}'"
         DIGEST=$(echo "$OUTPUT" | grep "^Digest:" | awk '{print $2}')
-        REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"
-        :> "$REFS_FILE"
-        echo "\"%s@%s\n\" \"$PUSHED\" \"$DIGEST\" >> \"$REFS_FILE\""
-        printf "%s@%s\n" "$PUSHED" "$DIGEST" >> "$REFS_FILE"
+        :> "${{ env.REFS_FILE }}"
+        printf "%s@%s\n" "$PUSHED" "$DIGEST" >> "${{ env.REFS_FILE }}"
       env:
         PACKAGED_CHART: "${{ runner.temp }}/packaged-chart/${{ inputs.app-name-prefix }}${{ inputs.app-name }}-${{ inputs.version }}.tgz"
         AWS_REGISTRY: ${{ inputs.registry == 'aws' && format('oci://{0}/charts' ,steps.login-ecr.outputs.registry) || '' }}
         QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'oci://quay.io/telicent/charts' || '' }}
+        REFS_FILE: "${{ runner.temp }}/quay-chart-refs.txt"
     - name: Install CoSign
       # Only run if dry run is explicitly set to 'false' and the image is being pushed to 'quay'.
       if: inputs.dry-run == 'false' && inputs.registry == 'quay'
@@ -155,8 +152,7 @@ runs:
       if: inputs.dry-run == 'false' && inputs.registry == 'quay'
       shell: bash
       run: |
-        REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"
-        if [[ ! -s "$REFS_FILE" ]]; then
+        if [[ ! -s "${{ env.REFS_FILE }}" ]]; then
           echo "No pushed chart references found to sign"
           exit 1
         fi
@@ -164,4 +160,6 @@ runs:
           [[ -n "$ref" ]] || continue
           echo "signing $ref"
           cosign sign --yes "$ref"
-        done < "$REFS_FILE"
+        done < "${{ env.REFS_FILE }}"
+      env:
+        REFS_FILE: "${{ runner.temp }}/quay-chart-refs.txt"

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -138,9 +138,9 @@ runs:
         echo "  ✅ Helm chart pushed successfully"
 
         # Capture the digest of the image that was pushed to enable signing.
-        pushed=$(echo "$output" | grep "^Pushed:" | awk '{print $2}')
-        digest=$(echo "$output" | grep "^Digest:" | awk '{print $2}')
-        printf "%s@%s\n" "$pushed" "$digest" >> "$refs_file"
+        PUSHED=$(echo "$OUTPUT" | grep "^Pushed:" | awk '{print $2}')
+        DIGEST=$(echo "$OUTPUT" | grep "^Digest:" | awk '{print $2}')
+        printf "%s@%s\n" "$PUSHED" "$DIGEST" >> "$refs_file"
       env:
         PACKAGED_CHART: "${{ runner.temp }}/packaged-chart/${{ inputs.app-name-prefix }}${{ inputs.app-name }}-${{ inputs.version }}.tgz"
         AWS_REGISTRY: ${{ inputs.registry == 'aws' && format('oci://{0}/charts' ,steps.login-ecr.outputs.registry) || '' }}

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -86,7 +86,7 @@ runs:
       # Only run if dry run is set to anything other than 'false', indicating that this is a dry run
       id: upload-image-artefact
       uses: actions/upload-artifact@v7
-      if: ${{ inputs.dry-run != 'false' }}
+      if: inputs.dry-run != 'false'
       with:
         name: ${{ inputs.app-name-prefix }}${{ inputs.app-name }}.tar
         path: /tmp/${{ inputs.app-name-prefix }}${{ inputs.app-name }}.tar
@@ -97,7 +97,7 @@ runs:
     - name: Configure AWS credentials from main account
       # Only run if dry run is explicitly set to 'false'
       # Dependabot triggered PRs don't have credentials to push Helm charts, so no need to run in this case either
-      if: ${{ inputs.registry == 'aws' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]' }}
+      if: inputs.registry == 'aws' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::098669589541:role/GitHubDeploymentRole
@@ -106,7 +106,7 @@ runs:
     - name: Docker Login to Amazon ECR
       # Only run if dry run is explicitly set to 'false'
       # Dependabot triggered PRs don't have credentials to push Helm charts, so no need to run in this case either
-      if: ${{ inputs.registry == 'aws' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]' }}
+      if: inputs.registry == 'aws' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
       with:
@@ -114,7 +114,7 @@ runs:
     - name: Log in to Quay.io (Helm)
       # Only run if dry run is explicitly set to 'false'
       # Dependabot triggered PRs don't have credentials to push Helm charts, so no need to run in this case either
-      if: ${{ inputs.registry == 'quay' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]' }}
+      if: inputs.registry == 'quay' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
       shell: bash
       run: |
         echo "$QUAY_TOKEN" | helm registry login quay.io --username "$QUAY_USERNAME" --password-stdin
@@ -123,7 +123,7 @@ runs:
         QUAY_TOKEN: ${{ inputs.quay-token }}
     - name: Push Helm chart
       # Only run if dry run is explicitly set to 'false'
-      if: ${{ inputs.dry-run == 'false' }}
+      if: inputs.dry-run == 'false'
       shell: bash
       run: |
 
@@ -147,11 +147,11 @@ runs:
         QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'oci://quay.io/telicent/charts' || '' }}
     - name: Install CoSign
       # Only run if dry run is explicitly set to 'false'
-      if: ${{ inputs.dry-run == 'false' }}
+      if: inputs.dry-run == 'false'
       uses: sigstore/cosign-installer@v3
     - name: Sign charts on Quay.io
       # Only run if dry run is explicitly set to 'false'
-      if: ${{ inputs.dry-run == 'false' }}
+      if: inputs.dry-run == 'false'
       shell: bash
       run: |
         REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -127,10 +127,6 @@ runs:
       shell: bash
       run: |
 
-        # Create/truncate `REFS_FILE` to use for cosigning.
-        REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"
-        : > "$REFS_FILE"
-
         # Push the Helm chart.
         echo "Pushing Helm chart "$PACKAGED_CHART" to ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }}"
         OUTPUT=$(helm push "$PACKAGED_CHART" ${{ env.AWS_REGISTRY }}${{ env.QUAY_REGISTRY }})
@@ -138,8 +134,13 @@ runs:
         echo "  ✅ Helm chart pushed successfully"
 
         # Capture the digest of the image that was pushed to enable signing.
+        echo "echo \"$OUTPUT\" | grep \"^Pushed:\" | awk '{print $2}'"
         PUSHED=$(echo "$OUTPUT" | grep "^Pushed:" | awk '{print $2}')
+        echo "echo \"$OUTPUT\" | grep \"^Digest:\" | awk '{print $2}'"
         DIGEST=$(echo "$OUTPUT" | grep "^Digest:" | awk '{print $2}')
+        REFS_FILE="$RUNNER_TEMP/quay-chart-refs.txt"
+        :> "$REFS_FILE"
+        echo "\"%s@%s\n\" \"$PUSHED\" \"$DIGEST\" >> \"$REFS_FILE\""
         printf "%s@%s\n" "$PUSHED" "$DIGEST" >> "$REFS_FILE"
       env:
         PACKAGED_CHART: "${{ runner.temp }}/packaged-chart/${{ inputs.app-name-prefix }}${{ inputs.app-name }}-${{ inputs.version }}.tgz"

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -140,7 +140,7 @@ runs:
         # Capture the digest of the image that was pushed to enable signing.
         PUSHED=$(echo "$OUTPUT" | grep "^Pushed:" | awk '{print $2}')
         DIGEST=$(echo "$OUTPUT" | grep "^Digest:" | awk '{print $2}')
-        printf "%s@%s\n" "$PUSHED" "$DIGEST" >> "$refs_file"
+        printf "%s@%s\n" "$PUSHED" "$DIGEST" >> "$REFS_FILE"
       env:
         PACKAGED_CHART: "${{ runner.temp }}/packaged-chart/${{ inputs.app-name-prefix }}${{ inputs.app-name }}-${{ inputs.version }}.tgz"
         AWS_REGISTRY: ${{ inputs.registry == 'aws' && format('oci://{0}/charts' ,steps.login-ecr.outputs.registry) || '' }}


### PR DESCRIPTION
Required in relation to https://telicent.atlassian.net/browse/TELDEVOPS-997

* Add image and chart singing in Quay (AWS Signing is used to sign containers in ECR).
* Ensure maximum image provenance is included with images.
* Add SBOM to images.