### PR TITLE
fix(push-container-image): upload tag manifest.json

### DIFF
--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -332,6 +332,21 @@ runs:
         build-args: |
           ${{ inputs.build-args }}
 
+    - name: Write tag-manifest
+      if: inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
+      shell: bash
+      run: echo "$DOCKER_METADATA" > /tmp/tag-manifest.json
+      env:
+        DOCKER_METADATA: ${{ steps.meta.outputs.json }}
+
+    - name: Upload tag-manifest artifact
+      if: inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
+      uses: actions/upload-artifact@v7
+      with:
+        name: tag-manifest-${{ inputs.app-name-prefix }}${{ inputs.app-name }}${{ inputs.image-suffix }}
+        path: /tmp/tag-manifest.json
+        retention-days: 7
+
     - name: Build container image tarball (dry run)
       # Only run if dry run is set to anything other than 'false', indicating that this is a dry run
       id: build-images-dry-run

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -206,7 +206,7 @@ runs:
       if: inputs.build-artifact
       with:
         name: ${{ inputs.build-artifact }}
-        path: ${{ inputs.path }}/${{ inputs.build-artifact }}/
+        path: ${{ inputs.build-artifact }}/
 
     - name: Get SBOM from artifact
       uses: actions/download-artifact@v4

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -206,7 +206,7 @@ runs:
       if: inputs.build-artifact
       with:
         name: ${{ inputs.build-artifact }}
-        path: ${{ inputs.build-artifact }}/
+        path: ${{ inputs.path }}/${{ inputs.build-artifact }}/
 
     - name: Get SBOM from artifact
       uses: actions/download-artifact@v4

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -335,7 +335,7 @@ runs:
     - name: Write tag-manifest
       if: inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
       shell: bash
-      run: echo "$DOCKER_METADATA" > /tmp/tag-manifest.json
+      run: echo "$DOCKER_METADATA" > ${{ runner.temp }}/tag-manifest.json
       env:
         DOCKER_METADATA: ${{ steps.meta.outputs.json }}
 
@@ -344,7 +344,7 @@ runs:
       uses: actions/upload-artifact@v7
       with:
         name: tag-manifest-${{ inputs.app-name-prefix }}${{ inputs.app-name }}${{ inputs.image-suffix }}
-        path: /tmp/tag-manifest.json
+        path: ${{ runner.temp }}/tag-manifest.json
         retention-days: 7
 
     - name: Build container image tarball (dry run)


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELDEVOPS-1098
📣 **(partially) AI-generated: Requires line-by-line review**

# Goal

Let devs run `gh run download` to published tag. Unblocks auto-helm chart PRs from local.

# Work Completed

```mermaid
flowchart TD
    subgraph fe["fe-mono-closed"]
        APP(["app-publish.yml"]):::ci -->|uses| PCI

        subgraph PCI["push-container-image (this PR)"]
            B([build-images]):::ci --> META["steps.meta.outputs.json"]:::ci
            META --> M([Write tag-manifest.json]):::new
            M --> U([Upload artifact]):::new
        end

        APP --> HELM([push-helm-chart]):::ci
        HELM --> DIS([repository_dispatch]):::ci
    end

    subgraph k8s["k8s-manifests"]
        DIS --> VER([update-app-version.yaml]):::ci
    end

    U -.->|"manual: gh run download"| SH(["update-helm-chart-image.sh --from="]):::local

    style fe fill:none,stroke:#333,stroke-dasharray:4 4,color:#aaa
    style PCI fill:none,stroke:#444,stroke-dasharray:4 4,color:#aaa
    style k8s fill:none,stroke:#333,stroke-dasharray:4 4,color:#aaa
    classDef ci fill:#21262d,color:#e6edf3,stroke:#30363d,stroke-width:1px
    classDef local fill:#555,color:#fff,stroke:#444
    classDef new fill:#21262d,color:#e6edf3,stroke:#00ff88,stroke-width:2px

    subgraph legend["Legend"]
        LN([new in this PR]):::new
    end
    style legend fill:none,stroke:#333,stroke-dasharray:4 4,color:#aaa
```

Two steps added to `push-container-image/action.yml` after `build-images`:

1. Write `steps.meta.outputs.json` → `/tmp/tag-manifest.json`
2. Upload as artifact `tag-manifest-<prefix><app><suffix>`

Guard: `dry-run == false` + actor != dependabot. No change for existing consumers.

# Proof ✅ 

- [Original trigger](https://github.com/Telicent-io/fe-mono-closed/actions/runs/26118019715) — [artifact](https://github.com/Telicent-io/fe-mono-closed/actions/runs/26118019715/artifacts/7092539514)
- [Live consumer run](https://github.com/Telicent-io/fe-mono-closed/actions/runs/26822875747) — all steps green

Post-merge: update `app-publish.yml` ref from `@TELDEVOPS-1098/tag-manifest` to `@main`.

# Related

https://github.com/Telicent-io/k8s-manifests/pull/2765

# Engineering Notes

JSON shape matches what `update-helm-chart-image.sh --from=` already consumes.