### PR TITLE
chore: fix sbom artefact pull

### DIFF
--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -213,7 +213,7 @@ runs:
       # Allow to continue even if SBOM is not found
       continue-on-error: true
       with:
-        name: ${{ steps.global.outputs.bom-artifact-name }}
+        name: ${{ steps.globals.outputs.bom-artifact-name }}
         path: ${{ inputs.PATH }}
 
     - name: Enable buildkit cache


### PR DESCRIPTION
Jira ticket: https://telicent.atlassian.net/browse/TELDEVOPS-1099

---

A bug has been spotted that means any previously generated SBOM artefact isn’t actually downloaded and therefore isn’t being added to our container images.

The fix is to correct a typo in ./github/actions/push-container-image/action.yml on line 216 - steps.global -> steps.globals