### PR TITLE
chore: always notify teams on image build

### DIFF
--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -438,8 +438,7 @@ runs:
         remote-vex: ${{ inputs.remote-vex }}
 
     - name: Notify MS Teams of image push
-      # Only runs if the workflow failed due to a failure of the 'build-image' step
-      if: failure() && steps.build-images.outcome == 'failure' && inputs.teams-webhook-url != ''
+      if: inputs.teams-webhook-url != ''
       uses: telicent-oss/shared-workflows/.github/actions/notify-teams@main
       with:
         app-name: ${{ inputs.app-name}}


### PR DESCRIPTION
Notify Teams on success as well as failure when an image is built and pushed using the `push-container-image` action. The notification will only be attempted if a Teams webhook/workflows URL is provided.