### PR TITLE
[CORE-1347] Add flag to ignore SBOM download process if need be and thus avoid distracting errors.

### DIFF
--- a/.github/actions/push-container-image/README.md
+++ b/.github/actions/push-container-image/README.md
@@ -88,6 +88,7 @@ specified.
 | Name | Default | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `package-directory` | | No | If release has multiple package that are SBOM targets, then set this to disambiguate SBOMs. |
+| `download-sbom` | `'true'` | No | Whether to attempt to download a previously uploaded SBOM artifact for use in the image build. |
 | `grype-scan-image` | `'true'` | No | Whether to run a Grype scan on the built image. |
 | `trivy-ignores` | | No | Name of trivy ignore file. Only allowed for BUILD image, MUST NOT be used with DEPLOY images. |
 | `trivy-scan-dockerfile`| `'true'` | No | Whether to run a Trivy scan on the Dockerfile used to build the image. |

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -214,7 +214,7 @@ runs:
 
     - name: Get SBOM from artifact
       uses: actions/download-artifact@v4
-      if: inputs.download-sbom == 'true'
+      if: ${{ inputs.download-sbom == 'true' }}
       # Allow to continue even if SBOM is not found
       continue-on-error: true
       with:

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -35,6 +35,10 @@ inputs:
     required: false
     default: .
     description: If release has multiple package that are SBOM targets, then set this to disambiguate SBOMs.
+  download-sbom:
+    required: false
+    default: 'true'
+    description: Whether to attempt to download a previously uploaded SBOM artifact for use in the image build.
   uses-maven:
     required: false
     default: 'false'
@@ -210,6 +214,7 @@ runs:
 
     - name: Get SBOM from artifact
       uses: actions/download-artifact@v4
+      if: inputs.download-sbom == 'true'
       # Allow to continue even if SBOM is not found
       continue-on-error: true
       with:


### PR DESCRIPTION
From reviewing the build logs from SC Search and Graph (and presumably the other BE apps) we never ever upload it so this always fails - and has "continue on error" set. It's a distraction when searching the logs for "error" that's best avoided. 