### PR TITLE
[CORE-1348] Updating libraries to address Node 20 deprecation warnings.

### DIFF
--- a/.github/actions/grype-image-scan/action.yml
+++ b/.github/actions/grype-image-scan/action.yml
@@ -61,11 +61,11 @@ runs:
         quay-token: "${{ inputs.quay-token }}"
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6.0.2
 
     - name: Configure AWS credentials from main account
       if: ${{ inputs.registry == 'aws' && inputs.image-from-artefact == 'false' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::098669589541:role/GitHubDeploymentRole
         aws-region: eu-west-2
@@ -73,20 +73,20 @@ runs:
 
     - name: Login to Amazon ECR
       if: ${{ inputs.registry == 'aws' && inputs.image-from-artefact == 'false' }}
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
       with:
         mask-password: true
 
     - name: Docker Login to Quay
       if: ${{ inputs.registry == 'quay' && inputs.image-from-artefact == 'false' }}
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4.1.0
       with:
         registry: quay.io
         username: ${{ inputs.quay-username }}
         password: ${{ inputs.quay-token }}
 
     - name: Download image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       if: ${{ inputs.image-from-artefact == 'true' }}
       with:
         name: ${{ inputs.scan-name }}.tar

--- a/.github/actions/promote-to-quay/action.yml
+++ b/.github/actions/promote-to-quay/action.yml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::098669589541:role/GitHubDeploymentRole
         aws-region: eu-west-2
@@ -50,7 +50,7 @@ runs:
         mask-password: true
 
     - name: Login to Quay
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.1.0
       with:
         registry: quay.io
         username: ${{ inputs.quay-username }}

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -184,11 +184,11 @@ runs:
         BOM_ARTIFACT_NAME: "${{ github.run_number }}${{ inputs.package-directory != '.' && format('-{0}', inputs.package-directory) || '' }}.sbom.json"
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6.0.2
 
     - name: Install Java and Maven
       if: inputs.uses-maven == 'true'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5.2.0
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk }}
@@ -202,14 +202,14 @@ runs:
       shell: bash
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       if: inputs.build-artifact
       with:
         name: ${{ inputs.build-artifact }}
         path: ${{ inputs.build-artifact }}/
 
     - name: Get SBOM from artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       # Allow to continue even if SBOM is not found
       continue-on-error: true
       with:
@@ -217,7 +217,7 @@ runs:
         path: ${{ inputs.PATH }}
 
     - name: Enable buildkit cache
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v5.0.5
       if: inputs.enable-buildkit-cache == 'true'
       with:
         path: /tmp/buildkit-cache/buildkit-state.tar
@@ -226,7 +226,7 @@ runs:
           ${{ runner.os }}-buildkit-
 
     - name: Load buildkit state from cache
-      uses: dashevo/gh-action-cache-buildkit-state@v1
+      uses: dashevo/gh-action-cache-buildkit-state@v1.0.3
       if: inputs.enable-buildkit-cache == 'true'
       with:
         builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
@@ -237,7 +237,7 @@ runs:
       id: aws-login
       # Only run if dry run is explicitly set to 'false'
       if: inputs.registry == 'aws' && inputs.dry-run == 'false'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::098669589541:role/GitHubDeploymentRole
         aws-region: eu-west-2
@@ -247,7 +247,7 @@ runs:
       # Only run if dry run is explicitly set to 'false'
       if: inputs.registry == 'aws' && inputs.dry-run == 'false'
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
       with:
         mask-password: true
 
@@ -255,24 +255,24 @@ runs:
       # Only run if dry run is explicitly set to 'false'
       # Dependabot triggered PRs don't have access to Quay credentials to push images, so no need to run in this case either
       if: inputs.registry == 'quay' && inputs.dry-run == 'false' && github.actor != 'dependabot[bot]'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.1.0
       with:
         registry: quay.io
         username: ${{ inputs.quay-username }}
         password: ${{ inputs.quay-token }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4.0.0
       with:
         platforms: all
 
     - name: Set up Docker buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4.0.0
 
     - name: Prepare Docker image names and tags
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6.0.0
       with:
         # Defines the base image names in repository/name format
         images: |
@@ -307,7 +307,7 @@ runs:
     - name: Build, tag, and push container image
       # Only run if dry run is explicitly set to 'false'
       id: build-images
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7.1.0
       if: inputs.dry-run == 'false'
       env:
         DOCKER_BUILDKIT: 1
@@ -333,7 +333,7 @@ runs:
     - name: Build container image tarball (dry run)
       # Only run if dry run is set to anything other than 'false', indicating that this is a dry run
       id: build-images-dry-run
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7.1.0
       if: inputs.dry-run != 'false'
       env:
         DOCKER_BUILDKIT: 1

--- a/.github/actions/push-helm-chart/action.yml
+++ b/.github/actions/push-helm-chart/action.yml
@@ -97,7 +97,7 @@ runs:
     - name: Configure AWS credentials from main account
       # Only run if dry run is explicitly set to 'false'
       if: inputs.registry == 'aws' && inputs.dry-run == 'false'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::098669589541:role/GitHubDeploymentRole
         aws-region: eu-west-2
@@ -106,7 +106,7 @@ runs:
       # Only run if dry run is explicitly set to 'false'
       if: inputs.registry == 'aws' && inputs.dry-run == 'false'
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
       with:
         mask-password: true
     - name: Log in to Quay.io (Helm)

--- a/.github/actions/python-prepare/action.yaml
+++ b/.github/actions/python-prepare/action.yaml
@@ -39,7 +39,7 @@ runs:
     - name: Configure CodeArtifact AWS credentials
       if: inputs.code-artefact-role != ''
       id: creds
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.code-artefact-role }}
         aws-region: eu-west-2

--- a/.github/actions/trivy-image-scan/action.yml
+++ b/.github/actions/trivy-image-scan/action.yml
@@ -69,11 +69,11 @@ runs:
         quay-token: "${{ inputs.quay-token }}"
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6.0.2
 
     - name: Configure AWS credentials from main account
       if: ${{ inputs.registry == 'aws' && inputs.image-from-artefact == 'false' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::098669589541:role/GitHubDeploymentRole
         aws-region: eu-west-2
@@ -81,20 +81,20 @@ runs:
 
     - name: Login to Amazon ECR
       if: ${{ inputs.registry == 'aws' && inputs.image-from-artefact == 'false' }}
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
       with:
         mask-password: true
 
     - name: Docker Login to Quay
       if: ${{ inputs.registry == 'quay' && inputs.image-from-artefact == 'false' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.1.0
       with:
         registry: quay.io
         username: ${{ inputs.quay-username }}
         password: ${{ inputs.quay-token }}
 
     - name: Download image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       if: ${{ inputs.image-from-artefact == 'true' }}
       with:
         name: ${{ inputs.scan-name }}.tar


### PR DESCRIPTION
The only update to be concerned about is the download artifact bumpt to v8. 

It's technically a little stricter but I don't think we're doing anything esoteric in our use - just needs looking out for. The rest (as far as I've been able to review) are suitably backwards compatible.