### PR TITLE
Also publish releases to AWS CodeArtifact (CORE-1353)

### DIFF
--- a/.github/actions/aws-codeartifact-login/README.md
+++ b/.github/actions/aws-codeartifact-login/README.md
@@ -14,7 +14,8 @@ automatically be masked as a secret.
 ### AWS Credentials
 
 This action assumes that your workflow has already obtained AWS credentials via
-the [configure-aws-credentials][2] action or similar. We recommend using the official AWS action for this.
+the [configure-aws-credentials][2] action or similar. We recommend using the 
+official AWS action for this.
 
 The pre-existing credentials available within your workflow job are then used
 to run the `aws codeartifact get-authorization-token` command to perform the
@@ -73,7 +74,7 @@ jobs:
 After our action has been called the CodeArtifact user and token are available
 as outputs in subsequent jobs and/or steps.
 
-For example a Maven user might then use a subsequent step to configure Maven with these credentials.
+For example a Maven user might then use subsequent steps to perform a Maven build with these credentials:
 
 ```yaml
       - name: Install Java and Maven
@@ -83,9 +84,22 @@ For example a Maven user might then use a subsequent step to configure Maven wit
           distribution: temurin
           cache: maven
           server-id: codeartifact
-          server-username: ${{ steps.code-artifact-login.outputs.user }}
-          server-password: ${{ steps.code-artifact-login.outputs.token }}
+          server-username: AWS_CODEARTIFACT_USERNAME
+          server-password: AWS_CODEARTIFACT_PASSWORD
+
+      - name: Maven Build
+        env:
+          AWS_CODEARTIFACT_USERNAME: ${{ steps.code-artifact-login.outputs.user }}
+          AWS_CODEARTIFACT_PASSWORD: ${{ steps.code-artifact-login.outputs.token }}
+        shell: bash
+        run: |
+          mvn install
 ```
+
+**NB** The `actions/setup-java` action uses indirection in creating the Maven settings file in that the username and
+password injected into the `settings.xml` are merely expressions pointing to environment variables.  Therefore any
+steps that actually needs the Maven credentials **MUST** set the environment variables previously specified in the
+inputs of the `actions/setup-java`.
 
 Or a Python user might do the following:
 

--- a/.github/workflows/maven-github-release.yml
+++ b/.github/workflows/maven-github-release.yml
@@ -85,6 +85,68 @@ on:
   workflow_dispatch:
 
 jobs:
+  codeartifact-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+
+      - name: Configure AWS credentials from main account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_DEPLOY_CODE_ARTIFACT }}
+          aws-region: eu-west-2
+          mask-aws-account-id: false
+
+      - name: AWS CodeArtifact Login
+        id: code-artifact-login
+        uses: telicent-oss/shared-workflows/.github/actions/aws-codeartifact-login@main
+        with:
+          domain: telicent 
+          owner: ${{ secrets.AWS_ACCOUNT_ID }}
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          # NB - The setup-java action creates a Maven settings file that uses indirection, so the username and password
+          #      here are merely environment variables.  Steps that actually want to perform actions against the AWS
+          #      CodeArtifact repository MUST set these environment variables from the outputs of the 
+          #      code-artifact-login step
+          server-id: codeartifact
+          server-username: AWS_CODEARTIFACT_USERNAME
+          server-password: AWS_CODEARTIFACT_PASSWORD
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      # Note this job only runs after a successful build job so safe to skip tests at this point
+      - name: Deploy Maven Release to AWS CodeArtifact
+        env:
+          # As Maven settings file references credentials via environment variables have to set those for the step that
+          # actually wants to interact with Code Artifact
+          AWS_CODEARTIFACT_USERNAME: ${{ steps.code-artifact-login.outputs.user }}
+          AWS_CODEARTIFACT_PASSWORD: ${{ steps.code-artifact-login.outputs.token }}
+        run: |
+          if [ "${{ runner.debug }}" -eq 1 ] 2>/dev/null; then
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} -P-telicent-oss \
+                ${{ inputs.MAVEN_ARGS }} -DskipTests \
+                -DaltReleaseDeploymentRepository=codeartifact::https://telicent-${{ secrets.AWS_ACCOUNT_ID }}.d.codeartifact.eu-west-2.amazonaws.com/maven/telicent-code-artifacts/
+          else
+            mvn ${{ inputs.MAVEN_DEPLOY_GOALS }} --batch-mode -P${{ inputs.DOCKER_PROFILE }} -P-telicent-oss \
+                ${{ inputs.MAVEN_ARGS }} ${{ inputs.MAVEN_DEBUG_ARGS }} -DskipTests \
+                -DaltReleaseDeploymentRepository=codeartifact::https://telicent-${{ secrets.AWS_ACCOUNT_ID }}.d.codeartifact.eu-west-2.amazonaws.com/maven/telicent-code-artifacts/
+          fi
+
   github-release:
     runs-on: ubuntu-latest
     if: ${{ github.ref_type == 'tag' }}
@@ -166,7 +228,8 @@ jobs:
         # This could error under a few circumstances:
         # 1 - The Developer is proactive and has already opened the PR from the release branch to main
         # 2 - The build has been restarted due to some transient failure so the PR was previously created
-        # Therefore set continue-on-error to true for this step
+        # 3 - The Developer created the release from a branch not named release/<version>
+        # Therefore set continue-on-error to true for this step so failure here doesn't block the build
         continue-on-error: true
         run: |
           gh pr create \


### PR DESCRIPTION
Adds another job to the github-release workflow that publishes the Maven releases to our internal AWS CodeArtifact repository