### PR TITLE
fix(push-container-image): avoid double slash in image registry path

### DIFF
--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -295,8 +295,8 @@ runs:
           type=raw,value=latest,enable=${{ env.TAG_LATEST }}
           type=raw,value=development,enable=${{ env.TAG_DEVELOPMENT }}
       env:
-        AWS_REGISTRY: ${{ inputs.registry == 'aws' && steps.login-ecr.outputs.registry || '' }}/
-        QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'quay.io/telicent' || '' }}/
+        AWS_REGISTRY: ${{ inputs.registry == 'aws' && format('{0}/', steps.login-ecr.outputs.registry) || '' }}
+        QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'quay.io/telicent/' || '' }}
         IMAGE_NAME: ${{ inputs.app-name-prefix }}${{ inputs.app-name }}${{ inputs.image-suffix }}
         TAG_DEVELOPMENT: ${{ inputs.allow-development-tag == 'true' || (inputs.allow-mutable-tags == 'true' && github.ref_name != inputs.main-branch) }}
         TAG_LATEST: ${{ inputs.allow-latest-tag == 'true' || (inputs.allow-mutable-tags == 'true' && github.ref_name == inputs.main-branch) }}


### PR DESCRIPTION
## Problem

`main` is currently broken for every consumer that builds container images to ECR. Example failure in [catalogue-api](https://github.com/Telicent-io/catalogue-api/actions/runs/29243347490/job/86794653681):

```
ERROR: failed to build: invalid tag "***.dkr.ecr.eu-west-2.amazonaws.com//catalogue-api:development": invalid reference format
```

## Cause

#259 moved the separator slash out of the `images:` template and onto each registry variable, but placed the `/` *after* the closing `}}` — so it applies to both branches of the ternary, not just the true branch:

```yaml
AWS_REGISTRY: ${{ inputs.registry == 'aws' && steps.login-ecr.outputs.registry || '' }}/
QUAY_REGISTRY: ${{ inputs.registry == 'quay' && 'quay.io/telicent' || '' }}/
```

On an AWS build, `QUAY_REGISTRY` evaluates to `''` and then gets a slash appended, becoming `/`. The concatenation `${AWS_REGISTRY}${QUAY_REGISTRY}${IMAGE_NAME}` therefore yields `<ecr>.amazonaws.com/` + `/` + `catalogue-api`, which Docker rejects.

## Fix

Move the slash inside the true branch using `format()`, so the inactive registry stays genuinely empty. This matches the idiom already used in `push-helm-chart/action.yml:164`, which is why that action never had this bug.

Resulting image names:
- `aws` → `<ecr>.dkr.ecr.eu-west-2.amazonaws.com/catalogue-api`
- `quay` → `quay.io/telicent/catalogue-api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)