### PR TITLE
[Minor] Add optional AWS authentication for maven builds

### DIFF
--- a/.github/actions/push-container-image/README.md
+++ b/.github/actions/push-container-image/README.md
@@ -45,6 +45,40 @@ specified.
 | `java-version` | `'21'` | No | Specifies the JDK version to install and build with. |
 | `jdk` | `'temurin'` | No | Specifies the JDK to use. |
 
+### CodeArtifact Options
+
+These only apply to `uses-maven` builds. Set `codeartifact-role` when the on-runner `mvn package` needs to
+resolve private Maven dependencies that live only in AWS CodeArtifact (i.e. artifacts that are not published to
+a public repository such as Maven Central). When it is omitted the action behaves as before, relying on public
+repositories and the Maven cache restored from the preceding Maven workflow.
+
+| Name | Default | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `codeartifact-role` | | No | ARN of the AWS IAM role to assume to obtain a CodeArtifact token for the Maven build. When set, the action logs into CodeArtifact and wires the token into Maven's `settings.xml`. When omitted, no CodeArtifact login is performed. |
+| `codeartifact-domain` | `'telicent'` | No | The AWS CodeArtifact domain used when obtaining a token. |
+| `codeartifact-domain-owner` | `'098669589541'` | No | The AWS account ID that owns the CodeArtifact domain. |
+| `codeartifact-repository-id` | `'aws-codeartifact-telicent'` | No | The Maven server id that matches the CodeArtifact repository declared in your `pom.xml`, so the obtained token is associated with the right server. |
+| `codeartifact-token-lifetime` | `'3600'` | No | Lifetime, in seconds, of the CodeArtifact token. |
+
+The calling job must have `id-token: write` permission and the supplied role must be assumable via OIDC and have
+permission to obtain a CodeArtifact authorization token. For example:
+
+```yaml
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: telicent-oss/shared-workflows/.github/actions/push-container-image@main
+        with:
+          app-name: my-service
+          registry: aws
+          dockerfile: docker/Dockerfile
+          uses-maven: true
+          role-to-assume: ${{ secrets.AWS_ROLE_DEPLOY }}
+          codeartifact-role: ${{ secrets.AWS_ROLE_DEPLOY_CODE_ARTIFACT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Container Registry Options
 
 | Name | Default | Required                           | Description |

--- a/.github/actions/push-container-image/README.md
+++ b/.github/actions/push-container-image/README.md
@@ -56,7 +56,7 @@ repositories and the Maven cache restored from the preceding Maven workflow.
 | :--- | :--- | :--- | :--- |
 | `codeartifact-role` | | No | ARN of the AWS IAM role to assume to obtain a CodeArtifact token for the Maven build. When set, the action logs into CodeArtifact and wires the token into Maven's `settings.xml`. When omitted, no CodeArtifact login is performed. |
 | `codeartifact-domain` | `'telicent'` | No | The AWS CodeArtifact domain used when obtaining a token. |
-| `codeartifact-domain-owner` | `'098669589541'` | No | The AWS account ID that owns the CodeArtifact domain. |
+| `codeartifact-domain-owner` | | No | The AWS account ID that owns the CodeArtifact domain. Not defaulted (to keep the account number out of this OSS action); pass it from a secret in the calling workflow, e.g. `${{ secrets.AWS_ACCOUNT_ID }}`. Required when `codeartifact-role` is set. |
 | `codeartifact-repository-id` | `'aws-codeartifact-telicent'` | No | The Maven server id that matches the CodeArtifact repository declared in your `pom.xml`, so the obtained token is associated with the right server. |
 | `codeartifact-token-lifetime` | `'3600'` | No | Lifetime, in seconds, of the CodeArtifact token. |
 
@@ -76,6 +76,7 @@ permission to obtain a CodeArtifact authorization token. For example:
           uses-maven: true
           role-to-assume: ${{ secrets.AWS_ROLE_DEPLOY }}
           codeartifact-role: ${{ secrets.AWS_ROLE_DEPLOY_CODE_ARTIFACT }}
+          codeartifact-domain-owner: ${{ secrets.AWS_ACCOUNT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -58,8 +58,10 @@ inputs:
     description: The AWS CodeArtifact domain used when obtaining a token. Only used when `codeartifact-role` is set.
   codeartifact-domain-owner:
     required: false
-    default: "098669589541"
-    description: The AWS account ID that owns the CodeArtifact domain. Only used when `codeartifact-role` is set.
+    description: |
+      The AWS account ID that owns the CodeArtifact domain. Intentionally not defaulted so that an AWS account
+      number is not embedded in this OSS action — pass it from a secret in the calling workflow, e.g.
+      `${{ secrets.AWS_ACCOUNT_ID }}`. Required when `codeartifact-role` is set.
   codeartifact-repository-id:
     required: false
     default: aws-codeartifact-telicent

--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -44,6 +44,34 @@ inputs:
     default: "false"
     description: Whether your build requires the JDK and Maven to be present.
 
+  # CodeArtifact options (only used by `uses-maven`)
+  codeartifact-role:
+    required: false
+    description: |
+      ARN of the AWS IAM role to assume in order to obtain an AWS CodeArtifact token so that a
+      `uses-maven` build can resolve private Maven dependencies. When omitted no CodeArtifact login is
+      performed and dependencies must be resolvable from public repositories or the restored Maven cache
+      (this preserves the previous behaviour).
+  codeartifact-domain:
+    required: false
+    default: telicent
+    description: The AWS CodeArtifact domain used when obtaining a token. Only used when `codeartifact-role` is set.
+  codeartifact-domain-owner:
+    required: false
+    default: "098669589541"
+    description: The AWS account ID that owns the CodeArtifact domain. Only used when `codeartifact-role` is set.
+  codeartifact-repository-id:
+    required: false
+    default: aws-codeartifact-telicent
+    description: |
+      The Maven server id that matches the CodeArtifact repository declared in your pom.xml
+      (`<repository>`/`<distributionManagement>`). The obtained token is associated with this server id so
+      that Maven authenticates correctly against that repository. Only used when `codeartifact-role` is set.
+  codeartifact-token-lifetime:
+    required: false
+    default: "3600"
+    description: Lifetime (in seconds) of the AWS CodeArtifact token. Only used when `codeartifact-role` is set.
+
   # Container registry options
   registry:
     required: true
@@ -192,20 +220,59 @@ runs:
     - name: Checkout
       uses: actions/checkout@v6.0.2
 
+    # When a CodeArtifact role is supplied, configure Maven with a server entry for the CodeArtifact
+    # repository. The credentials reference environment variables that are populated by the CodeArtifact
+    # login step below at the time the Maven build runs.
+    - name: Install Java and Maven (with CodeArtifact)
+      if: inputs.uses-maven == 'true' && inputs.codeartifact-role != ''
+      uses: actions/setup-java@v5.2.0
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.jdk }}
+        cache: maven
+        server-id: ${{ inputs.codeartifact-repository-id }}
+        server-username: AWS_CODEARTIFACT_USER
+        server-password: AWS_CODEARTIFACT_TOKEN
+
     - name: Install Java and Maven
-      if: inputs.uses-maven == 'true'
+      if: inputs.uses-maven == 'true' && inputs.codeartifact-role == ''
       uses: actions/setup-java@v5.2.0
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk }}
         cache: maven
 
-    # NB - Assumption here is that this action has been called after the Maven workflow has been called so the
-    #      Maven Cache already has all our dependencies present in it and tests have already passed
+    # Obtain a short-lived AWS CodeArtifact token so the Maven build can resolve private dependencies.
+    # Only runs when a CodeArtifact role ARN is supplied. The main-account credentials required for ECR
+    # are configured later, after the Maven build, so assuming the CodeArtifact role here is safe.
+    - name: Configure AWS credentials for CodeArtifact
+      if: inputs.uses-maven == 'true' && inputs.codeartifact-role != ''
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.codeartifact-role }}
+        aws-region: eu-west-2
+        mask-aws-account-id: true
+
+    - name: AWS CodeArtifact Login
+      id: codeartifact-login
+      if: inputs.uses-maven == 'true' && inputs.codeartifact-role != ''
+      uses: telicent-oss/shared-workflows/.github/actions/aws-codeartifact-login@main
+      with:
+        domain: ${{ inputs.codeartifact-domain }}
+        owner: ${{ inputs.codeartifact-domain-owner }}
+        token-lifetime: ${{ inputs.codeartifact-token-lifetime }}
+
+    # NB - When no CodeArtifact role is supplied the assumption is that this action has been called after
+    #      the Maven workflow, so the restored Maven cache already contains all dependencies and tests have
+    #      already passed. Supplying `codeartifact-role` makes private dependency resolution robust to
+    #      cache misses (for example after a dependency version bump changes the cache key).
     - name: Quick Maven Build
       if: inputs.uses-maven == 'true'
       run: mvn package -U --batch-mode -DskipTests
       shell: bash
+      env:
+        AWS_CODEARTIFACT_USER: ${{ steps.codeartifact-login.outputs.user }}
+        AWS_CODEARTIFACT_TOKEN: ${{ steps.codeartifact-login.outputs.token }}
 
     - name: Download build artifact
       uses: actions/download-artifact@v8


### PR DESCRIPTION
Attempting to address failures in Smart Cache Documents builds (see [here](https://github.com/Telicent-io/smart-cache-documents/actions/runs/29260883760/job/86858934308). 

Long story short, recent CI changes [here](https://github.com/Telicent-io/smart-cache-documents/commit/8ec1b05),  means that the action no longer inherits the CodeArtifact login within the push-container-image and so is getting the unauthorised errors in Githib.

This changes means that for Maven builds we can pass those through. 

