### PR TITLE
Fix Push Container Image action

### DIFF
--- a/.github/actions/push-container-image/action.yml
+++ b/.github/actions/push-container-image/action.yml
@@ -61,7 +61,7 @@ inputs:
     description: |
       The AWS account ID that owns the CodeArtifact domain. Intentionally not defaulted so that an AWS account
       number is not embedded in this OSS action — pass it from a secret in the calling workflow, e.g.
-      `${{ secrets.AWS_ACCOUNT_ID }}`. Required when `codeartifact-role` is set.
+      `secrets.AWS_ACCOUNT_ID`. Required when `codeartifact-role` is set.
   codeartifact-repository-id:
     required: false
     default: aws-codeartifact-telicent


### PR DESCRIPTION
Using GitHub Expressions syntax in the `description` of the input  causes templating failures

> Error: telicent-oss/shared-workflows/main/.github/actions/push-container-image/action.yml (Line: 61, Col: 18): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.AWS_ACCOUNT_ID
> Error: GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid. telicent-oss/shared-workflows/main/.github/actions/push-container-image/action.yml (Line: 61, Col: 18): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.AWS_ACCOUNT_ID