### PR TITLE
Add Maven Central Audit job to Maven builds (CORE-1353)

### DIFF
--- a/.github/workflows/maven-central-audit.yml
+++ b/.github/workflows/maven-central-audit.yml
@@ -1,0 +1,86 @@
+name: Maven Central Audit
+
+on:
+  workflow_call:
+    inputs:
+      MAVEN_REPOSITORY_ID:
+        required: false
+        type: string
+        default: central
+        description: |
+          Specifies the ID of the repository to which `SNAPSHOT`s and Releases are published, this **MUST** match 
+          the ID of a repository defined in the `pom.xml` for the project in order for credentials to be correctly 
+          configured.
+      JAVA_VERSION:
+        required: false
+        type: number
+        default: 21
+        description: |
+          Specifies the JDK version to install and build with.  Defaults to 21.
+      JDK:
+        required: false
+        type: string
+        default: temurin
+        description: |
+          Specifies the JDK to use, defaults to `temurin`.
+    secrets:
+      MVN_USER_NAME:
+        required: false
+        description: |
+          Username for authenticating to a Maven repository to publish releases.
+      MVN_USER_PWD:
+        required: false
+        description: |
+          Password/Token for authenticating to a Maven repository to publish releases.
+      GPG_PRIVATE_KEY:
+        required: false
+        description: |
+          A GPG Private Key that will be used to sign the built artifacts during the build process.  The `pom.xml`
+          **MUST** invoke the `maven-gpg-plugin` for this to have an effect.
+      GPG_PASSPHRASE:
+        required: false
+        description: |
+          The passphrase protecting the provided GPG Private Key.
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  maven-central-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Maven Central Audit
+    env:
+      # These have to be exported into the environment due to how the setup-java action configures the Maven
+      # settings.xml file to avoid directly embedding credentials into it.
+      MAVEN_USERNAME: ${{ secrets.MVN_USER_NAME }}
+      MAVEN_PASSWORD: ${{ secrets.MVN_USER_PWD }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v5.3.0
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          server-id: ${{ inputs.MAVEN_REPOSITORY_ID }}
+          # Forced to use indirection here, the setup-java action configures the Maven settings.xml to reference
+          # the credentials via environment variables
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Run Maven Central Audit
+        uses: telicent-oss/mvn-central-audit@v1
+        with:
+          # Specify limits, if a release would be above this size then the build will be failed
+          max-files: 600
+          max-size: 16000000 # 16MB

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -191,7 +191,7 @@ jobs:
       contents: read
     needs:
       - cache-dependencies
-    uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@add-mvn-central-audit
+    uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@main
     with:
       MAVEN_REPOSITORY_ID: ${{ inputs.MAVEN_REPOSITORY_ID }}
       JAVA_VERSION: ${{ inputs.JAVA_VERSION }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -184,6 +184,18 @@ jobs:
           images: ${{ inputs.PUBLIC_IMAGES }}
           restore-only: false
 
+  maven-central-audit:
+    # Only run audit for OSS repositories that will be publishing to Maven Central
+    if: ${{ contains(github.repository_owner, 'oss') }}
+    needs:
+      - cache-dependencies
+    uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@add-mvn-central-audit
+    with:
+      MAVEN_REPOSITORY_ID: ${{ inputs.MAVEN_REPOSITORY_ID }}
+      JAVA_VERSION: ${{ inputs.JAVA_VERSION }}
+      JDK: ${{ inputs.JDK }}
+    secrets: inherit
+
   build:
     needs: 
       - cache-dependencies

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -187,6 +187,8 @@ jobs:
   maven-central-audit:
     # Only run audit for OSS repositories that will be publishing to Maven Central
     if: ${{ contains(github.repository_owner, 'oss') }}
+    permissions:
+      contents: read
     needs:
       - cache-dependencies
     uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@add-mvn-central-audit

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -214,7 +214,7 @@ jobs:
       contents: read
     needs:
       - cache-dependencies
-    uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@add-mvn-central-audit
+    uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@main
     with:
       MAVEN_REPOSITORY_ID: ${{ inputs.MAVEN_REPOSITORY_ID }}
       JAVA_VERSION: ${{ inputs.JAVA_VERSION }}

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -206,6 +206,40 @@ jobs:
         with:
           images: ${{ inputs.PUBLIC_IMAGES }}
           restore-only: false
+
+  maven-central-audit:
+    needs:
+      - cache-dependencies
+    runs-on: ubuntu-latest
+    name: Maven Central Audit
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v5.3.0
+        with:
+          java-version: ${{ inputs.JAVA_VERSION }}
+          distribution: ${{ inputs.JDK }}
+          cache: maven
+          server-id: ${{ inputs.MAVEN_REPOSITORY_ID }}
+          # Forced to use indirection here, the setup-java action configures the Maven settings.xml to reference
+          # the credentials via environment variables
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Run Maven Central Audit
+        uses: telicent-oss/mvn-central-audit@v1
+        with:
+          # Specify limits, if a release would be above this size then the build will be failed
+          max-files: 600
+          max-size: 16000000 # 16MB
   
   build:
     needs: 

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -208,38 +208,16 @@ jobs:
           restore-only: false
 
   maven-central-audit:
+    # Only run audit for OSS repositories that will be publishing to Maven Central
+    if: ${{ contains(github.repository_owner, 'oss') }}
     needs:
       - cache-dependencies
-    runs-on: ubuntu-latest
-    name: Maven Central Audit
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v6.0.2
-
-      - name: Install Java and Maven
-        uses: actions/setup-java@v5.3.0
-        with:
-          java-version: ${{ inputs.JAVA_VERSION }}
-          distribution: ${{ inputs.JDK }}
-          cache: maven
-          server-id: ${{ inputs.MAVEN_REPOSITORY_ID }}
-          # Forced to use indirection here, the setup-java action configures the Maven settings.xml to reference
-          # the credentials via environment variables
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7.0.0
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Run Maven Central Audit
-        uses: telicent-oss/mvn-central-audit@v1
-        with:
-          # Specify limits, if a release would be above this size then the build will be failed
-          max-files: 600
-          max-size: 16000000 # 16MB
+    uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@add-mvn-central-audit
+    with:
+      MAVEN_REPOSITORY_ID: ${{ inputs.MAVEN_REPOSITORY_ID }}
+      JAVA_VERSION: ${{ inputs.JAVA_VERSION }}
+      JDK: ${{ inputs.JDK }}
+    secrets: inherit
   
   build:
     needs: 

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -210,6 +210,8 @@ jobs:
   maven-central-audit:
     # Only run audit for OSS repositories that will be publishing to Maven Central
     if: ${{ contains(github.repository_owner, 'oss') }}
+    permissions:
+      contents: read
     needs:
       - cache-dependencies
     uses: telicent-oss/shared-workflows/.github/workflows/maven-central-audit.yml@add-mvn-central-audit

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -44,7 +44,10 @@ The serial Maven workflow does the following:
     - Does a `mvn dependency:go-offline` to populate a GitHub Actions Cache used in the subsequent job
 2. A `cache-docker-images` job that:
     - Pulls and caches specified `PUBLIC_IMAGES` if on the `MAIN_BRANCH`
-3. A `build` job that:
+3. A `maven-central-audit` job that:
+    - Verifies that the repository will produce a release to Maven Central that falls within defined release limits
+      (total files and total size)
+4. A `build` job that:
     - Configures Java and Maven
     - Optionally logs into DockerHub if configured to do so (see `USES_DOCKERHUB_IMAGES` in [workflow
       inputs](#workflow-inputs))
@@ -55,7 +58,7 @@ The serial Maven workflow does the following:
     - Scans the project for high/critical severity vulnerabilities attaching reports to the build
    vulnerabilities with `trivy`
     - Adds the detected Maven project version (value of `project.version`) to the job outputs
-4. A `github-release` job that runs only when the built version is not a `SNAPSHOT` and the workflow was triggered from
+5. A `github-release` job that runs only when the built version is not a `SNAPSHOT` and the workflow was triggered from
    a Git tag:
     - Configures Java and Maven
     - Does a quick Maven build (`mvn install -DskipTests`) since this job is dependent on the `build` job being
@@ -69,10 +72,13 @@ For the parallel build version of the workflow the steps are slightly different:
 
 1. A `cache-dependencies` job, this is the same as for the serial workflow
 2. A `cache-docker-images` job, this is the same as for the serial workflow
-3. A `detect-modules` job that:
+3. A `maven-central-audit` job that:
+    - Verifies that the repository will produce a release to Maven Central that falls within defined release limits
+      (total files and total size)
+4. A `detect-modules` job that:
     - Configures Java and Maven
     - Generates a JSON Output that is an array of the modules found in the repository
-4. A `build` job for each detected module that:
+5. A `build` job for each detected module that:
     - Configures Java and Maven
     - Optionally logs into DockerHub if configured to do so (see `USES_DOCKERHUB_IMAGES` in [workflow
       inputs](#workflow-inputs))
@@ -81,14 +87,14 @@ For the parallel build version of the workflow the steps are slightly different:
     - Tests the module with `mvn install -pl :module`
       - **NB** If the workflow detects no changes to any `src/` or `pom.xml` files then `-DskipTests` is added to the
          `mvn` arguments here to avoid re-running tests when no Java changes are present e.g. PRs that update only docs
-4. A `scan-and-publish` job that: 
+6. A `scan-and-publish` job that: 
     - Configures Java and Maven
     - Does a quick Maven build (`mvn install -DskipTests`) since this job is dependent on the `build` jobs being
       successful which has built and verified each individual module
     - Scans the project for high/critical severity vulnerabilities attaching reports to the build vulnerabilities with
    `trivy`
     - Adds the detected Maven project version (value of `project.version`) to the job outputs
-5. A `github-release` job that is the same as the serial build
+7. A `github-release` job that is the same as the serial build
 
 Note that many aspects of the above may be configured via [workflow inputs](#workflow-inputs).
 


### PR DESCRIPTION
This will provide early warning of builds that are releasing more than they should in terms of total files/file size.  Limits are hardcoded to add some headroom over our largest current repository in release terms - telicent-oss/smart-caches-core - and to not be too high a percentage of the Central free usage limits (accepting that given what we currently release we can't stay within some of those)

This job runs concurrently with the build job so should finish before the builds and not add any additional runtime to builds

Example job with this enabled - https://github.com/telicent-oss/smart-caches-core/actions/runs/30456146500/job/90590923804