### PR TITLE
Don't run Maven Central Audit for Dependabot PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -186,7 +186,8 @@ jobs:
 
   maven-central-audit:
     # Only run audit for OSS repositories that will be publishing to Maven Central
-    if: ${{ contains(github.repository_owner, 'oss') }}
+    # Also don't run for Dependabot PRs as Dependabot doesn't have access to the GPG secrets
+    if: ${{ contains(github.repository_owner, 'oss') && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
     needs:

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -209,7 +209,8 @@ jobs:
 
   maven-central-audit:
     # Only run audit for OSS repositories that will be publishing to Maven Central
-    if: ${{ contains(github.repository_owner, 'oss') }}
+    # Also don't run for Dependabot PRs as Dependabot doesn't have access to the GPG secrets
+    if: ${{ contains(github.repository_owner, 'oss') && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
     needs:


### PR DESCRIPTION
This job requires the GPG secrets which Dependabot does not have access to (for good reason) so skip the job when the PR is from Dependabot

E.g. broken build: https://github.com/telicent-oss/smart-cache-storage/actions/runs/30781745264/job/91588005785?pr=159