### PR TITLE
SonarQube scans respect Maven profiles

### DIFF
--- a/.github/actions/mvn-sast-scanning/action.yaml
+++ b/.github/actions/mvn-sast-scanning/action.yaml
@@ -54,6 +54,10 @@ inputs:
     required: false
     default: ""
     description: Additional arguments to pass to the Maven invocations.
+  maven-profiles:
+    required: false
+    default: "docker"
+    description: Specifies the Maven profile(s) to activate (if needed)
 
 outputs:
   dashboard-url:
@@ -125,7 +129,7 @@ runs:
         if [ "$NEED_COMPILE" = "true" ]; then
           # Sonar's Java analyser needs bytecode, but tests are never rerun here, so coverage
           # must be supplied via the coverage-report-paths input in this scenario
-          mvn test-compile --batch-mode -DskipTests -Dgpg.skip -Dcyclonedx.skip \
+          mvn test-compile -P${{ inputs.maven-profiles }} --batch-mode -DskipTests -Dgpg.skip -Dcyclonedx.skip \
             -Dmaven.javadoc.skip -Dmaven.source.skip -q $EXTRA_MAVEN_ARGS
         fi
 
@@ -148,7 +152,7 @@ runs:
           args+=("-Dsonar.coverage.jacoco.xmlReportPaths=$COVERAGE_PATHS")
         fi
         status=0
-        mvn "${args[@]}" $EXTRA_MAVEN_ARGS || status=$?
+        mvn "${args[@]}" -P${{ inputs.maven-profiles }} $EXTRA_MAVEN_ARGS || status=$?
         REPORT=$(find . -path '*/target/sonar/report-task.txt' -print -quit)
         if [ -n "$REPORT" ]; then
           echo "dashboard-url=$(grep '^dashboardUrl=' "$REPORT" | cut -d'=' -f2-)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -353,6 +353,7 @@ jobs:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           compile: 'false'
           maven-args: ${{ inputs.MAVEN_ARGS }} ${{ steps.extra-maven-args.outputs.args }}
+          maven-profiles: ${{ inputs.DOCKER_PROFILE }}
           fail-on-quality-gate: ${{ inputs.SONAR_QUALITY_GATE }}
       
       - name: Publish SonarQube Dashboard Link

--- a/.github/workflows/parallel-maven.yml
+++ b/.github/workflows/parallel-maven.yml
@@ -405,6 +405,7 @@ jobs:
           compile: 'true'
           coverage-report-paths: ${{ github.workspace }}/sonar-coverage/**/jacoco.xml
           maven-args: ${{ inputs.MAVEN_ARGS }}
+          maven-profiles: ${{ inputs.DOCKER_PROFILE }}
           fail-on-quality-gate: ${{ inputs.SONAR_QUALITY_GATE }}
       
       - name: Publish SonarQube Dashboard Link


### PR DESCRIPTION
Some builds require specific Maven profiles, e.g. docker, to be set in order to build all code correctly.  For some parallel Maven builds this was resulting in SonarQube scanning failures e.g. https://github.com/telicent-oss/smart-caches-core/actions/runs/31378214632/job/93425612074

This commit adds a maven-profiles input to the Maven scanning action plus updates the Maven workflows to pass through the `DOCKER_PROFILE` workflow input as the value for that input.