### PR TITLE
Don't cache Maven dependencies on Windows

### DIFF
--- a/.github/workflows/maven-cache-dependencies.yml
+++ b/.github/workflows/maven-cache-dependencies.yml
@@ -21,11 +21,7 @@ on:
 
 jobs:
   cache-dependencies:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
We'd already removed the ability for the CI/CD pipeline to build on Windows but we were still caching Maven dependencies on Windows which is entirely unnecessary and can be removed.